### PR TITLE
Clean code

### DIFF
--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/Colors.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/Colors.kt
@@ -6,9 +6,6 @@ import io.data2viz.geom.Point
 import io.data2viz.math.Angle
 
 
-// TODO : move to common and remove expect when available
-internal expect fun Int.toString(radix: Int): String
-
 
 object Colors {
 

--- a/color/d2v-color-js/src/main/kotlin/io/data2viz/color/color.kt
+++ b/color/d2v-color-js/src/main/kotlin/io/data2viz/color/color.kt
@@ -1,4 +1,0 @@
-package io.data2viz.color
-
-
-internal actual fun Int.toString(radix: Int): String  = asDynamic().toString(radix)

--- a/color/d2v-color-jvm/src/main/kotlin/io/data2viz/color/ColorJVM.kt
+++ b/color/d2v-color-jvm/src/main/kotlin/io/data2viz/color/ColorJVM.kt
@@ -1,3 +1,0 @@
-package io.data2viz.color
-
-internal actual fun Int.toString(radix: Int): String = Integer.toString(this, radix)

--- a/core/d2v-core-common/src/test/kotlin/io/data2viz/geom/PathTests.kt
+++ b/core/d2v-core-common/src/test/kotlin/io/data2viz/geom/PathTests.kt
@@ -449,6 +449,7 @@ class PathTests : TestBase() {
         }
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun path_rect_appends_M_h_v_h_and_Z_commands() {
         with(path()){
@@ -461,7 +462,7 @@ class PathTests : TestBase() {
     @Test
     @Ignore
     fun closePathShouldComeBackToFirstPoint() {
-        var lastCommand: ClosePath = ClosePath()
+        var lastCommand: ClosePath
         with(path()){
             moveTo(10.0, 10.0)
             lineTo(20.0, 20.0)

--- a/core/d2v-core-js/build.gradle
+++ b/core/d2v-core-js/build.gradle
@@ -1,8 +1,8 @@
 
 dependencies{
     expectedBy project(":core:d2v-core-common")
-    testCompile project(":format:d2v-format-common")
-    testCompile project(":format:d2v-format-js")
+    testApi project(":format:d2v-format-common")
+    testApi project(":format:d2v-format-js")
 }
 
 apply from: rootProject.file('gradle/test-js.gradle')

--- a/examples/ex-sankey/ex-sankey-js/src/main/kotlin/ExSankeyJs.kt
+++ b/examples/ex-sankey/ex-sankey-js/src/main/kotlin/ExSankeyJs.kt
@@ -1,30 +1,7 @@
 package io.data2viz.examples.sankey
 
-import io.data2viz.viz.JsCanvasRenderer
-import org.w3c.dom.CanvasRenderingContext2D
-import org.w3c.dom.HTMLCanvasElement
-import kotlin.browser.document
+import io.data2viz.viz.bindRendererOnNewCanvas
 
-
-@Suppress("unused")
-fun main(args: Array<String>) {
-
-    val (canvas, context) = newCanvas(vizWidth.toInt(), vizHeight.toInt())
-    val viz = sankeyViz()
-    viz.renderer = JsCanvasRenderer(context, viz)
-    viz.render()
-    println("ChordViz rendered")
-
-}
-
-
-data class CanvasContext(val canvas: HTMLCanvasElement, val context2D: CanvasRenderingContext2D)
-
-private fun newCanvas(width: Int, height: Int): CanvasContext {
-    val canvas = document.createElement("canvas") as HTMLCanvasElement
-    val context = canvas.getContext("2d") as CanvasRenderingContext2D
-    context.canvas.width = width
-    context.canvas.height = height
-    document.querySelector("body")!!.appendChild(canvas)
-    return CanvasContext(canvas, context)
+fun main() {
+    sankeyViz().bindRendererOnNewCanvas()
 }

--- a/viz/d2v-viz-js/src/test/kotlin/io/data2viz/viz/TestRenderings.kt
+++ b/viz/d2v-viz-js/src/test/kotlin/io/data2viz/viz/TestRenderings.kt
@@ -3,6 +3,7 @@ package io.data2viz.viz
 import org.w3c.dom.HTMLCanvasElement
 import kotlin.browser.document
 
+@Suppress("DEPRECATION")
 fun main(args: Array<String>) {
     val tests = allRenderingTests
 


### PR DESCRIPTION
Remove old code not needed anymore due to new features in Kotlin 1.3
Remove compilation warning (unused parameters, ...)
Fix gradle warnings.