### PR TITLE
limit expositions of functions in "Force"

### DIFF
--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/Force.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/Force.kt
@@ -1,10 +1,9 @@
 package io.data2viz.force
 
+// TODO make Force constructors internal (use only functions)
+interface Force
 
-
-
-
-interface Force {
+abstract class InternalForce : Force {
 
     /**
      * Assigns nodes to this force.
@@ -12,10 +11,8 @@ interface Force {
      * nodes change via simulation.nodes.
      * A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid
      * repeatedly performing work during each application of the force.
-     *
-     * Todo should be internal. No use outside of package
      */
-    fun assignNodes(nodes: List<ForceNode>)
+    internal abstract fun assignNodes(nodes: List<ForceNode>)
 
     /**
      * Applies this force, optionally observing the specified alpha.
@@ -23,5 +20,5 @@ interface Force {
      * forces may apply to a subset of nodes, or behave differently.
      * For example, forceLink applies to the source and target of each link.
      */
-    fun applyForceToNodes(alpha: Double)
+    internal abstract fun applyForceToNodes(alpha: Double)
 }

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceCenter.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceCenter.kt
@@ -3,6 +3,7 @@ package io.data2viz.force
 import io.data2viz.geom.Point
 
 fun forceCenter(center: Point) = ForceCenter(center)
+fun forceXY(center: Point) = ForceCenter(center)
 
 // TODO : strength
 /**
@@ -13,7 +14,7 @@ fun forceCenter(center: Point) = ForceCenter(center)
  * This force helps keeps nodes in the center of the viewport, and unlike the positioning force,
  * it does not distort their relative positions.
  */
-class ForceCenter(val center: Point = Point(.0, .0)) : Force {
+class ForceCenter(val center: Point = Point(.0, .0)) : InternalForce() {
 
     private var _nodes = listOf<ForceNode>()
 

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceCollision.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceCollision.kt
@@ -1,7 +1,5 @@
 package io.data2viz.force
 
-import io.data2viz.geom.Point
-import io.data2viz.geom.Vector
 import io.data2viz.quadtree.*
 import kotlin.math.sqrt
 
@@ -13,7 +11,7 @@ fun forceCollision(init: ForceCollision.() -> Unit) = ForceCollision().apply(ini
  * radius(a) + radius(b).
  * To reduce jitter, this is by default a “soft” constraint with a configurable strength and iteration count.
  */
-class ForceCollision : Force {
+class ForceCollision : InternalForce() {
 
     private val x = { node: ForceNode -> node.x }
     private val y = { node: ForceNode -> node.y }

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceLink.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceLink.kt
@@ -27,7 +27,7 @@ fun forceLink(init: ForceLink.() -> Unit = {}) = ForceLink().apply(init)
  *
  *
  */
-class ForceLink : Force {
+class ForceLink : InternalForce() {
 
     private var nodes       = listOf<ForceNode>()
 

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceNBody.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceNBody.kt
@@ -20,7 +20,7 @@ internal fun jiggle() = (Random.nextDouble() - 0.5) * EPSILON
  * Unlike links, which only affect two linked nodes, the charge force is global: every node affects every other node,
  * even if they are on disconnected subgraphs.
  */
-class ForceNBody : Force {
+class ForceNBody : InternalForce() {
 
     private var theta2 = .81
     private var distanceMin2 = 1.0

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceRadial.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceRadial.kt
@@ -10,7 +10,7 @@ fun forceRadial(init:ForceRadial.()->Unit) = ForceRadial().apply(init)
 /**
  * Creates a new positioning force towards a circle of the specified radius centered at "center" Point.
  */
-class ForceRadial : Force {
+class ForceRadial : InternalForce() {
 
     /**
      * Sets the circle radius to the specified function, re-evaluates the radius accessor for each node.

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceSimulation.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceSimulation.kt
@@ -153,7 +153,7 @@ class ForceSimulation {
     }
 
     private fun initializeForce(force: Force) {
-        force.assignNodes(nodes)
+        (force as InternalForce).assignNodes(nodes)
     }
 
 
@@ -177,7 +177,7 @@ class ForceSimulation {
 
 
         _forces.values.forEach { force ->
-            force.applyForceToNodes(alpha)
+            (force as InternalForce).applyForceToNodes(alpha)
         }
 
         nodes.forEach { node ->

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceX.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceX.kt
@@ -8,7 +8,7 @@ fun forceX(init:ForceX.()->Unit = {}) = ForceX().apply(init)
  * Creates a new positioning force along the x-axis towards the given position x.
  * If x is not specified, it defaults to 0.
  */
-class ForceX : Force {
+class ForceX : InternalForce() {
 
     /**
      * Sets the x-coordinate accessor to the specified function, re-evaluates the x-accessor for each node.

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceY.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceY.kt
@@ -7,7 +7,7 @@ fun forceY(init: ForceY.() -> Unit = {}) = ForceY().apply(init)
  * Creates a new positioning force along the y-axis towards the given position y.
  * If y is not specified, it defaults to 0.
  */
-class ForceY : Force {
+class ForceY : InternalForce() {
 
     /**
      * Sets the y-coordinate accessor to the specified function, re-evaluates the y-accessor for each node.


### PR DESCRIPTION
The functions from the "Force" interface where public, this could lead to some issues, as they are not meant to be used outside of the project (they should only be called by the Simulation object).