### PR TITLE
No RectF allocation in hot code path

### DIFF
--- a/viz/d2v-viz-android/src/main/java/io/data2viz/viz/AndroidCanvasRenderer.kt
+++ b/viz/d2v-viz-android/src/main/java/io/data2viz/viz/AndroidCanvasRenderer.kt
@@ -58,6 +58,7 @@ class VizView(val viz: Viz, context: Context) : View(context) {
         if (drawCount == 100){
             val delta = System.currentTimeMillis() - startTime
             val fps = 100_000 / delta
+            Log.v("FPS", fps.toString())
             startTime = System.currentTimeMillis()
             drawCount = -1
         }

--- a/viz/d2v-viz-android/src/main/java/io/data2viz/viz/AndroidPathRenderer.kt
+++ b/viz/d2v-viz-android/src/main/java/io/data2viz/viz/AndroidPathRenderer.kt
@@ -19,6 +19,7 @@ fun PathNode.render(renderer: AndroidCanvasRenderer) {
     }
 
     val path = android.graphics.Path()
+    val rect = RectF()
 
     fun arcTo(lastX: Double, lastY: Double, cpX: Double, cpY: Double, x: Double, y: Double, r: Double) {
 
@@ -40,8 +41,9 @@ fun PathNode.render(renderer: AndroidCanvasRenderer) {
                         (-180f - alpha.radToDeg.toFloat()) % 360f
 
             path.moveTo(lastX.dp, lastY.dp)
+            rect.set ((cx - r).dp, (cy - r).dp, (cx + r).dp, (cy + r).dp)
             path.arcTo(
-                    RectF((cx - r).dp, (cy - r).dp, (cx + r).dp, (cy + r).dp),
+                    rect,
                     startAngle,
                     sweepAngle, false)
             path.lineTo(x.dp, y.dp)
@@ -60,7 +62,7 @@ fun PathNode.render(renderer: AndroidCanvasRenderer) {
                 is ClosePath -> path.close()
                 is Arc -> {
                     val r = cmd.radius
-                    val rect = RectF((cmd.centerX - r).dp, (cmd.centerY - r).dp, (cmd.centerX + r).dp, (cmd.centerY + r).dp)
+                    rect.set((cmd.centerX - r).dp, (cmd.centerY - r).dp, (cmd.centerX + r).dp, (cmd.centerY + r).dp)
                     val startAngle = cmd.startAngle.radToDegrees()
                     var sweepAngle = cmd.endAngle.radToDegrees() - startAngle
 


### PR DESCRIPTION
When I ran the world demo for the first time I saw frame drops here and there which made me curious how the Android layer is actually implemented. When I attached the Android Studio Memory profiler I figured that GC kicks in way too often, most prominently are boxing / unboxing of  `Double` values in `Resample.kt` due to lambda invocations:

![screenshot](https://puu.sh/C3tzc/e4d8021dcd.png)

Just as an example, for this innocent looking Kotlin code

```
var currentPoint : Foo = ::defaultPoint
```

the following equivalent Java code is generated

```
         this.currentPoint = new Function3((<undefinedtype>)this) {
                     // $FF: synthetic method
                     // $FF: bridge method
                     public Object invoke(Object var1, Object var2, Object var3) {
                        this.invoke(((Number)var1).doubleValue(), ((Number)var2).doubleValue(), ((Number)var3).doubleValue());
                        return Unit.INSTANCE;
                     }

                     public final void invoke(double p1, double p2, double p3) {
                        ((<undefinedtype>)this.receiver).defaultPoint(p1, p2, p3);
                     }

                     public final KDeclarationContainer getOwner() {
                        return Reflection.getOrCreateKotlinClass(<undefinedtype>.class);
                     }

                     public final String getName() {
                        return "defaultPoint";
                     }

                     public final String getSignature() {
                        return "defaultPoint(DDD)V";
                     }
                  };
```

Basic issue seems to be type erasure on the JVM side here and out of my head I wouldn't know how to fix this without rewriting this particular code to be less functional. But you should definitely look into this, as these amounts of allocations on "hot" drawing paths will certainly hurt performance really badly.

Attached is a small PR that picks a low-hanging fruit that goes into the same direction - the reusage of allocated `RectF` instances. Just by changing these 4 lines of code I gained approx. 1fps more in the Geo demo. (~55fps vs ~54fps on my Android 9 emulator).