### PR TITLE
Use percent on colors

### DIFF
--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/Color.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/Color.kt
@@ -2,7 +2,7 @@ package io.data2viz.color
 
 import io.data2viz.math.*
 
-data class ColorStop(val percent:Double, val color: Color)
+data class ColorStop(val percent:Percent, val color: Color)
 
 interface ColorOrGradient
 
@@ -25,7 +25,7 @@ interface Color : ColorOrGradient {
     val r:Int
     val g:Int
     val b:Int
-    val alpha:Double
+    val alpha:Percent
     val rgbHex:String
 
     /**
@@ -57,7 +57,7 @@ interface Color : ColorOrGradient {
     fun darken(strength: Double = 1.0):Color
     fun saturate(strength: Double = 1.0):Color
     fun desaturate(strength: Double = 1.0):Color
-    fun withAlpha(alpha: Double):Color
+    fun withAlpha(alpha: Percent):Color
 
     /**
      * Change the perceived lightness of the color and return a new Color.

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/ColorConversions.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/ColorConversions.kt
@@ -85,7 +85,7 @@ internal fun HslColor.toRgba(): RgbColor =
         )
     else {
         val q = if (l < 50.pct) l * (100.pct + s) else l + s - l * s
-        val p = Percent(2 * (l - q).value)
+        val p = Percent(2 * l.value - q.value)
         Colors.rgb(
             (hue2rgb(p.value, q.value, h + angle120deg) * 255).roundToInt(),
             (hue2rgb(p.value, q.value, h) * 255).roundToInt(),

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/ColorConversions.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/ColorConversions.kt
@@ -28,7 +28,7 @@ internal fun RgbColor.toLaba(): LabColor {
     val x = xyz2lab((0.4124564f * labB + 0.3575761f * labA + 0.1804375f * labL) / Xn)
     val y = xyz2lab((0.2126729f * labB + 0.7151522f * labA + 0.0721750f * labL) / Yn)
     val z = xyz2lab((0.0193339f * labB + 0.1191920f * labA + 0.9503041f * labL) / Zn)
-    return Colors.lab(116.0 * y - 16, 500.0 * (x - y), 200.0 * (y - z), alpha)
+    return Colors.lab((116.0 * y - 16).pct, 500.0 * (x - y), 200.0 * (y - z), alpha)
 }
 
 internal fun RgbColor.toHsla(): HslColor {
@@ -53,12 +53,12 @@ internal fun RgbColor.toHsla(): HslColor {
     } else {
         s = if (l > 0 && l < 1) .0 else h
     }
-    return Colors.hsl(h.deg, s, l, alpha)
+    return Colors.hsl(h.deg, Percent(s), Percent(l), alpha)
 }
 
 internal fun LabColor.toRgba(): RgbColor {
     // map CIE LAB to CIE XYZ
-    var y = (labL + 16) / 116f
+    var y = ((labL.value * 100.0) + 16) / 116f
     var x = y + (labA / 500f)
     var z = y - (labB / 200f)
     y = Yn * lab2xyz(y)
@@ -78,18 +78,18 @@ internal fun LabColor.toRgba(): RgbColor {
 internal fun HslColor.toRgba(): RgbColor =
     if (isAchromatic())     // achromatic
         Colors.rgb(
-            (l * 255).roundToInt(),
-            (l * 255).roundToInt(),
-            (l * 255).roundToInt(),
+            (l.value * 255).roundToInt(),
+            (l.value * 255).roundToInt(),
+            (l.value * 255).roundToInt(),
             alpha
         )
     else {
-        val q = if (l < 0.5f) l * (1 + s) else l + s - l * s
-        val p = 2 * l - q
+        val q = if (l < 50.pct) l * (100.pct + s) else l + s - l * s
+        val p = Percent(2 * (l - q).value)
         Colors.rgb(
-            (hue2rgb(p, q, h + angle120deg) * 255).roundToInt(),
-            (hue2rgb(p, q, h) * 255).roundToInt(),
-            (hue2rgb(p, q, h - angle120deg) * 255).roundToInt(),
+            (hue2rgb(p.value, q.value, h + angle120deg) * 255).roundToInt(),
+            (hue2rgb(p.value, q.value, h) * 255).roundToInt(),
+            (hue2rgb(p.value, q.value, h - angle120deg) * 255).roundToInt(),
             alpha
         )
     }

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/Colors.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/Colors.kt
@@ -4,6 +4,8 @@ package io.data2viz.color
 
 import io.data2viz.geom.Point
 import io.data2viz.math.Angle
+import io.data2viz.math.Percent
+import io.data2viz.math.pct
 
 
 // TODO : move to common and remove expect when available
@@ -18,27 +20,36 @@ object Colors {
      * Instantiate a color using its rgb Int value and alpha. Should be used with hexadecimal literal.
      * @sample: `Colors.rgb(0x0b0b0b, .5)`
      */
-    fun rgb(rgb:Int, alpha: Double = 1.0): RgbColor = RgbColor(rgb, alpha)
+    fun rgb(rgb:Int, alpha: Percent = 100.pct): RgbColor = RgbColor(rgb, alpha)
 
     /**
      * Instantiate a color using its r,g,b Int values and alpha
      * @sample: `Colors.rgb(128, 128, 128, .5)`
      */
-    fun rgb(red: Int, green: Int, blue: Int, alpha: Double = 1.0): RgbColor {
+    fun rgb(red: Int, green: Int, blue: Int, alpha: Percent = 100.pct): RgbColor {
         val rgb = (red.coerceIn(0, 255) shl 16) + (green.coerceIn(0, 255) shl 8) + blue.coerceIn(0, 255)
         return rgb(rgb, alpha)
     }
 
-    fun lab(lightness: Double, aComponent: Double, bComponent: Double, alpha: Double = 1.0) =
+    fun lab(lightness: Percent, aComponent: Double, bComponent: Double, alpha: Percent = 100.pct) =
             LabColor(lightness, aComponent, bComponent, alpha)
 
-    fun hsl(hue: Angle, saturation: Double, lightness: Double, alpha: Double = 1.0) =
+    fun lab(lightness: Percent, aComponent: Int, bComponent: Int, alpha: Percent = 100.pct) =
+            LabColor(lightness, aComponent.toDouble(), bComponent.toDouble(), alpha)
+
+    fun hsl(hue: Angle, saturation: Percent, lightness: Percent, alpha: Percent = 100.pct) =
             HslColor(hue, saturation, lightness, alpha)
 
-    fun hcl(hue: Angle, chroma: Double, luminance: Double, alpha: Double = 1.0) =
+    fun hcl(hue: Angle, chroma: Double, luminance: Percent, alpha: Percent = 100.pct) =
             HclColor(hue, chroma, luminance, alpha)
 
-    fun lch(luminance: Double, chroma: Double, hue: Angle, alpha: Double = 1.0) = hcl(hue, chroma, luminance, alpha)
+    fun hcl(hue: Angle, chroma: Int, luminance: Percent, alpha: Percent = 100.pct) =
+            HclColor(hue, chroma.toDouble(), luminance, alpha)
+
+    fun lch(luminance: Percent, chroma: Double, hue: Angle, alpha: Percent = 100.pct) =
+            hcl(hue, chroma, luminance, alpha)
+
+    fun lch(luminance: Percent, chroma: Int, hue: Angle, alpha: Percent = 100.pct) = hcl(hue, chroma, luminance, alpha)
 
 
     /***************************** GRADIENTS *********************************************************/

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/HclColor.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/HclColor.kt
@@ -18,10 +18,10 @@ import kotlin.math.max
 class HclColor
 
 @Deprecated("Deprecated", ReplaceWith("Colors.hcl(h,c,l,alpha)", "io.data2viz.colors.Colors"))
-internal constructor(val h: Angle, val c: Double, lightness: Double, a: Double = 1.0) : Color {
+internal constructor(val h: Angle, val c: Double, lightness: Percent, a: Percent = 100.pct) : Color {
 
     val l = lightness//.coerceIn(.0, 100.0)
-    override val alpha = a.coerceIn(.0, 1.0)
+    override val alpha = a.coerceToDefault()
 
     override val rgb = toRgb().rgb
     override val rgba = toRgb().rgba
@@ -38,14 +38,14 @@ internal constructor(val h: Angle, val c: Double, lightness: Double, a: Double =
     override fun toHcl(): HclColor = this
     override fun toHsl(): HslColor = toLab().toHsl()
 
-    override fun brighten(strength: Double): Color = Colors.hcl(h, c, (l + (Kn * strength)), alpha)
-    override fun darken(strength: Double): Color = Colors.hcl(h, c, (l - (Kn * strength)), alpha)
+    override fun brighten(strength: Double): Color = Colors.hcl(h, c, (l + (Kn * strength).pct), alpha)
+    override fun darken(strength: Double): Color = Colors.hcl(h, c, (l - (Kn * strength).pct), alpha)
     override fun saturate(strength: Double): Color = Colors.hcl(h, max(.0, (c + (Kn * strength))), l, alpha)
     override fun desaturate(strength: Double): Color = Colors.hcl(h, max(.0, (c - (Kn * strength))), l, alpha)
-    override fun withAlpha(alpha: Double) = Colors.hcl(h, c, l, alpha)
+    override fun withAlpha(alpha: Percent) = Colors.hcl(h, c, l, alpha)
     override fun withHue(hue: Angle) = Colors.hcl(hue, c, l, alpha)
 
-    fun isAchromatic() = (c == .0) || (l <= .0) || (l >= 100.0)
+    fun isAchromatic() = (c == .0) || (l.value <= .0) || (l.value >= 1.0)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/HclColor.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/HclColor.kt
@@ -10,10 +10,10 @@ import kotlin.math.max
  * HCL has been adopted by information visualization practitioners to present data without the bias implicit in
  * using varying saturation.
  *
- * @param h hue: Angle in degree
- * @param c chroma: Float, the upper bound for chroma depends on hue and luminance (typically in 0..230)
- * @param lightness: Float a value in the range [0,100] giving the lightness of the colour (in percent)
- * @param alpha: Float between 0 and 1
+ * @param h hue: Angle
+ * @param c chroma: Double, the upper bound for chroma depends on hue and luminance (typically in 0..230)
+ * @param lightness: Percent, value between 0% and 100%
+ * @param alpha: Opacity, value between 0% and 100%
  */
 class HclColor
 

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/HslColor.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/HslColor.kt
@@ -12,12 +12,12 @@ import io.data2viz.math.*
  */
 class HslColor
 @Deprecated("Deprecated", ReplaceWith("Colors.hsl(hue,saturation,luminance,a)", "io.data2viz.colors.Colors"))
-internal constructor(hue: Angle, saturation: Double, lightness: Double, a: Double = 1.0) : Color {
+internal constructor(hue: Angle, saturation: Percent, lightness: Percent, a: Percent = 100.pct) : Color {
 
     val h = hue.normalize()
-    val s = saturation.coerceIn(.0, 1.0)
-    val l = lightness.coerceIn(.0, 1.0)
-    override val alpha = a.coerceIn(.0, 1.0)
+    val s = saturation.coerceToDefault()
+    val l = lightness.coerceToDefault()
+    override val alpha = a.coerceToDefault()
 
     override val rgb = toRgb().rgb
     override val rgba = toRgb().rgba
@@ -38,10 +38,10 @@ internal constructor(hue: Angle, saturation: Double, lightness: Double, a: Doubl
     override fun darken(strength: Double): Color = toRgb().darken(strength)
     override fun saturate(strength: Double): Color = toRgb().saturate(strength)
     override fun desaturate(strength: Double): Color = toRgb().desaturate(strength)
-    override fun withAlpha(alpha: Double) = Colors.hsl(h, s, l, alpha)
+    override fun withAlpha(alpha: Percent) = Colors.hsl(h, s, l, alpha)
     override fun withHue(hue: Angle) = toHcl().withHue(hue)
 
-    fun isAchromatic() = (s == .0) || (l <= .0) || (l >= 1.0)
+    fun isAchromatic() = (s.value == .0) || (l.value <= .0) || (l.value >= 1.0)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -59,5 +59,5 @@ internal constructor(hue: Angle, saturation: Double, lightness: Double, a: Doubl
         return result
     }
 
-    override fun toString() = "HSL(${h.deg}°, ${s*100}%, ${l*100}%, alpha=$alpha)"
+    override fun toString() = "HSL(${h.deg}°, $s, $l, alpha=$alpha)"
 }

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/HslColor.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/HslColor.kt
@@ -5,10 +5,10 @@ import io.data2viz.math.*
 /**
  * Create a color in the HSL color space
  *
- * @param h hue:Angle in degree
- * @param s saturation:Float between 0 and 1
- * @param l lightness:Float between 0 and 1
- * @param alpha:Float between 0 and 1
+ * @param h hue: Angle
+ * @param s saturation: Percent, value between 0% and 100%
+ * @param l lightness: Percent, value between 0% and 100%
+ * @param alpha: Opacity, value between 0% and 100%
  */
 class HslColor
 @Deprecated("Deprecated", ReplaceWith("Colors.hsl(hue,saturation,luminance,a)", "io.data2viz.colors.Colors"))

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/LabColor.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/LabColor.kt
@@ -5,10 +5,10 @@ import io.data2viz.math.*
 /**
  * Create a color in the LAB color space (CIE L*a*b* D65 whitepoint)
  *
- * @param lightness :Float between 0 and 100
- * @param aComponent "a"-component:Float for green-red between -128 and +128
- * @param bComponent "b"-component:Float for blue-yellow between -128 and +128
- * @param alpha:Opacity between 0 and 1
+ * @param lightness: Percent, value between 0% and 100%
+ * @param aComponent "a"-component: Double for green-red between -128 and +128
+ * @param bComponent "b"-component: Double for blue-yellow between -128 and +128
+ * @param alpha: Opacity, value between 0% and 100%
  */
 class LabColor
 @Deprecated("Deprecated", ReplaceWith("Colors.lab(labL,labA,labB,alpha)", "io.data2viz.colors.Colors"))

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/LabColor.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/LabColor.kt
@@ -12,13 +12,13 @@ import io.data2viz.math.*
  */
 class LabColor
 @Deprecated("Deprecated", ReplaceWith("Colors.lab(labL,labA,labB,alpha)", "io.data2viz.colors.Colors"))
-internal constructor(lightness: Double, aComponent: Double, bComponent: Double, a: Double = 1.0) : Color {
+internal constructor(lightness: Percent, aComponent: Double, bComponent: Double, a: Percent = 100.pct) : Color {
 
     // TODO : need to choose behavior: if values are coerced the results are not what expected when referring to test values from chroma.js
     val labL = lightness//.coerceIn(.0, 100.0)
     val labA = aComponent//.coerceIn(-128.0, 128.0)
     val labB = bComponent//.coerceIn(-128.0, 128.0)
-    override val alpha = a.coerceIn(.0, 1.0)
+    override val alpha = a.coerceToDefault()
 
     override val rgb = toRgb().rgb
     override val rgba = toRgb().rgba
@@ -35,11 +35,11 @@ internal constructor(lightness: Double, aComponent: Double, bComponent: Double, 
     override fun toHcl(): HclColor = toHcla()
     override fun toHsl(): HslColor = toRgb().toHsl()
 
-    override fun brighten(strength: Double): Color = Colors.lab((labL + (Kn * strength)), labA, labB, alpha)
-    override fun darken(strength: Double): Color = Colors.lab((labL - (Kn * strength)), labA, labB, alpha)
+    override fun brighten(strength: Double): Color = Colors.lab((labL + (Kn * strength).pct), labA, labB, alpha)
+    override fun darken(strength: Double): Color = Colors.lab((labL - (Kn * strength).pct), labA, labB, alpha)
     override fun saturate(strength: Double): Color = toHcl().saturate(strength)
     override fun desaturate(strength: Double): Color = toHcl().desaturate(strength)
-    override fun withAlpha(alpha: Double) = Colors.lab(labL, labA, labB, alpha)
+    override fun withAlpha(alpha: Percent) = Colors.lab(labL, labA, labB, alpha)
     override fun withHue(hue: Angle) = toHcl().withHue(hue)
 
     override fun equals(other: Any?): Boolean {

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/LinearGradient.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/LinearGradient.kt
@@ -3,6 +3,8 @@
 package io.data2viz.color
 
 import io.data2viz.geom.Point
+import io.data2viz.math.Percent
+import io.data2viz.math.pct
 
 // TODO : move to "core.geom" ?
 // TODO : remove access to x1, y1, x2, y2
@@ -29,13 +31,13 @@ interface HasStartAndEnd {
 
 data class LinearGradientFirstColorBuilder
 internal constructor(val start: Point, val end: Point) {
-    fun withColor(startColor: Color, percent: Double = .0): LinearGradientSecondColorBuilder =
+    fun withColor(startColor: Color, percent: Percent = 0.pct): LinearGradientSecondColorBuilder =
         LinearGradientSecondColorBuilder(this, ColorStop(percent, startColor))
 }
 
 data class LinearGradientSecondColorBuilder
 internal constructor(val builder: LinearGradientFirstColorBuilder, val firstColor: ColorStop) {
-    fun andColor(color: Color, percent: Double = 1.0): LinearGradient = LinearGradient()
+    fun andColor(color: Color, percent: Percent = 100.pct): LinearGradient = LinearGradient()
         .apply {
             x1 = builder.start.x
             y1 = builder.start.y
@@ -59,8 +61,8 @@ internal constructor() : Gradient, HasStartAndEnd {
     override val colorStops: List<ColorStop>
         get() = colors.toList()
 
-    fun andColor(color: Color, percent: Double): LinearGradient {
-        colors.add(ColorStop(percent.coerceIn(.0, 1.0), color))
+    fun andColor(color: Color, percent: Percent): LinearGradient {
+        colors.add(ColorStop(percent.coerceToDefault(), color))
         return this
     }
 }

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/RadialGradient.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/RadialGradient.kt
@@ -3,6 +3,8 @@
 package io.data2viz.color
 
 import io.data2viz.geom.Point
+import io.data2viz.math.Percent
+import io.data2viz.math.pct
 
 // TODO : move to "core.geom" ?
 // TODO : remove access to cx, cy, leave only access to center
@@ -20,13 +22,13 @@ interface HasCenter {
 
 data class RadialGradientFirstColorBuilder
 internal constructor(val center: Point, val radius: Double) {
-    fun withColor(startColor: Color, percent: Double = .0): RadialGradientSecondColorBuilder =
+    fun withColor(startColor: Color, percent: Percent = 0.pct): RadialGradientSecondColorBuilder =
         RadialGradientSecondColorBuilder(this, ColorStop(percent, startColor))
 }
 
 data class RadialGradientSecondColorBuilder
 internal constructor(val builder: RadialGradientFirstColorBuilder, val firstColor: ColorStop) {
-    fun andColor(color: Color, percent: Double = 1.0): RadialGradient = RadialGradient()
+    fun andColor(color: Color, percent: Percent = 100.pct): RadialGradient = RadialGradient()
         .apply {
             cx = builder.center.x
             cy = builder.center.y
@@ -49,8 +51,8 @@ constructor(): Gradient, HasCenter {
     override val colorStops: List<ColorStop>
         get() = colors.toList()
 
-    fun andColor(color: Color, percent: Double): RadialGradient {
-        colors.add(ColorStop(percent.coerceIn(.0, 1.0), color))
+    fun andColor(color: Color, percent: Percent): RadialGradient {
+        colors.add(ColorStop(percent.coerceToDefault(), color))
         return this
     }
 }

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/RgbColor.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/RgbColor.kt
@@ -1,6 +1,8 @@
 package io.data2viz.color
 
 import io.data2viz.math.Angle
+import io.data2viz.math.Percent
+import io.data2viz.math.pct
 
 /**
  * Implementation of Color as an rgb integer and an alpha channel.
@@ -12,9 +14,9 @@ import io.data2viz.math.Angle
  */
 class RgbColor
     @Deprecated("Use factory function or Int.col extension.", ReplaceWith("Colors.rgb(rgb,a)", "io.data2viz.colors.Colors"))
-    constructor(override val rgb: Int, a: Double = 1.0) : Color {
+    constructor(override val rgb: Int, a: Percent = 100.pct) : Color {
 
-    override val alpha = a.coerceIn(.0, 1.0)
+    override val alpha = a.coerceToDefault()
 
     override val r: Int
         get() = (rgb shr 16) and 0xff
@@ -70,7 +72,7 @@ class RgbColor
     override val rgba: String
         get() = "rgba($r, $g, $b, $alpha)"
 
-    override fun withAlpha(alpha: Double) = Colors.rgb(rgb, alpha)
+    override fun withAlpha(alpha: Percent) = Colors.rgb(rgb, alpha)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/color/d2v-color-common/src/main/kotlin/io/data2viz/color/RgbColor.kt
+++ b/color/d2v-color-common/src/main/kotlin/io/data2viz/color/RgbColor.kt
@@ -70,7 +70,7 @@ class RgbColor
                 (rgb and 0xf).toString(16)
 
     override val rgba: String
-        get() = "rgba($r, $g, $b, $alpha)"
+        get() = "rgba($r, $g, $b, ${alpha.value})"
 
     override fun withAlpha(alpha: Percent) = Colors.rgb(rgb, alpha)
 

--- a/color/d2v-color-common/src/test/kotlin/io/data2viz/color/ColorTests.kt
+++ b/color/d2v-color-common/src/test/kotlin/io/data2viz/color/ColorTests.kt
@@ -10,6 +10,7 @@ import io.data2viz.color.Colors.Web.white
 import io.data2viz.geom.Point
 import io.data2viz.math.Angle
 import io.data2viz.math.deg
+import io.data2viz.math.pct
 import io.data2viz.test.TestBase
 import kotlin.math.absoluteValue
 import kotlin.math.round
@@ -18,8 +19,14 @@ import kotlin.test.Test
 class ColorTests : TestBase() {
 
     @Test
+    fun rgba() {
+        listOf("rgba(0, 0, 0, 1.0)", "rgba(0, 0, 0, 1)") should contain("#000000".col.rgba)
+        "#000000".col.withAlpha(50.pct).rgba shouldBe "rgba(0, 0, 0, 0.5)"
+    }
+
+    @Test
     fun set_r_g_b() {
-        var color = Colors.rgb(0xFFFFFF)
+        var color = RgbColor(0xFFFFFF)
         color = color.withRed(0xab)
         color.rgb shouldBe 0xabffff
 
@@ -38,20 +45,14 @@ class ColorTests : TestBase() {
     }
 
     @Test
-    fun rgba() {
-        listOf("rgba(0, 0, 0, 1.0)", "rgba(0, 0, 0, 1)") should contain("#000000".col.rgba)
-        "#000000".col.withAlpha(.5).rgba shouldBe "rgba(0, 0, 0, 0.5)"
-    }
-
-    @Test
     fun color_to_hex_should_be_7_char() {
         black.rgbHex shouldBe "#000000"
     }
 
     @Test
     fun RGB_coercing_under_0_and_over_255_color_channel() {
-        Colors.rgb(300, -300, 256, -2.5) shouldBe Colors.rgb(255, 0, 255, .0)
-        Colors.rgb(-300, 300, -256, 2.5) shouldBe Colors.rgb(0, 255, 0, 1.0)
+        Colors.rgb(300, -300, 256, (-250).pct) shouldBe Colors.rgb(255, 0, 255, 0.pct)
+        Colors.rgb(-300, 300, -256, 250.pct) shouldBe Colors.rgb(0, 255, 0, 100.pct)
     }
 
     /**
@@ -59,27 +60,27 @@ class ColorTests : TestBase() {
      */
     @Test
     fun HSLA_to_RGBA_reference() {
-        Colors.hsl(0.deg, .0, .0).toRgb() shouldBe black
-        Colors.hsl(240.deg, .0, .0).toRgb() shouldBe black
-        Colors.hsl(126.deg, .0, .0).toRgb() shouldBe black
-        Colors.hsl(6800.deg, .0, .0).toRgb() shouldBe black
+        Colors.hsl(0.deg, 0.pct, 0.pct).toRgb() shouldBe black
+        Colors.hsl(240.deg, 0.pct, 0.pct).toRgb() shouldBe black
+        Colors.hsl(126.deg, 0.pct, 0.pct).toRgb() shouldBe black
+        Colors.hsl(6800.deg, 0.pct, 0.pct).toRgb() shouldBe black
 
-        Colors.hsl(0.deg, .0, 1.0).toRgb() shouldBe white
-        Colors.hsl(240.deg, .0, 1.0).toRgb() shouldBe white
-        Colors.hsl(126.deg, .0, 1.0).toRgb() shouldBe white
-        Colors.hsl(680.deg, .0, 1.0).toRgb() shouldBe white
+        Colors.hsl(0.deg, 0.pct, 100.pct).toRgb() shouldBe white
+        Colors.hsl(240.deg, 0.pct, 100.pct).toRgb() shouldBe white
+        Colors.hsl(126.deg, 0.pct, 100.pct).toRgb() shouldBe white
+        Colors.hsl(680.deg, 0.pct, 100.pct).toRgb() shouldBe white
 
-        Colors.hsl(32.deg, 0.80, 0.80, .0).toRgb() shouldBe Colors.rgb(0xf5cfa3, 0.0)
-        Colors.hsl(260.deg, 0.20, 0.44, 1.0).toRgb() shouldBe Colors.rgb(0x695a87, 1.0)
-        Colors.hsl(300.deg, 0.98, 0.16, .3).toRgb() shouldBe Colors.rgb(0x510151, .3)
-        Colors.hsl(16.deg, 0.75, 0.23, .5).toRgb() shouldBe Colors.rgb(0x67260f, .5)
+        Colors.hsl(32.deg, 80.pct, 80.pct, 0.pct).toRgb() shouldBe RgbColor(0xf5cfa3, 0.pct)
+        Colors.hsl(260.deg, 20.pct, 44.pct, 100.pct).toRgb() shouldBe RgbColor(0x695a87, 100.pct)
+        Colors.hsl(300.deg, 98.pct, 16.pct, 30.pct).toRgb() shouldBe RgbColor(0x510151, 30.pct)
+        Colors.hsl(16.deg, 75.pct, 23.pct, 50.pct).toRgb() shouldBe RgbColor(0x67260f, 50.pct)
 
-        Colors.hsl(580.deg, .3, .2).toRgb() shouldBe Colors.rgb(0x242e42)
-        Colors.hsl((-200).deg, .3, .2).toRgb() shouldBe Colors.rgb(0x244238)
-        Colors.hsl((-120).deg, .7, .6).toRgb() shouldBe Colors.rgb(0x5252e0)
-        Colors.hsl(400.deg, .2, .5).toRgb() shouldBe Colors.rgb(0x998866)
-        Colors.hsl(512.deg, 7.0, 2.0).toRgb() shouldBe Colors.rgb(0xffffff)
-        Colors.hsl(124.deg, .1, 2.0).toRgb() shouldBe Colors.rgb(0xffffff)
+        Colors.hsl(580.deg, 30.pct, 20.pct).toRgb() shouldBe RgbColor(0x242e42)
+        Colors.hsl((-200).deg, 30.pct, 20.pct).toRgb() shouldBe RgbColor(0x244238)
+        Colors.hsl((-120).deg, 70.pct, 60.pct).toRgb() shouldBe RgbColor(0x5252e0)
+        Colors.hsl(400.deg, 20.pct, 50.pct).toRgb() shouldBe RgbColor(0x998866)
+        Colors.hsl(512.deg, 700.pct, 200.pct).toRgb() shouldBe RgbColor(0xffffff)
+        Colors.hsl(124.deg, 10.pct, 200.pct).toRgb() shouldBe RgbColor(0xffffff)
     }
 
     // TODO and check who's right (chroma.js, w3schools converter or data2viz) ?
@@ -95,136 +96,136 @@ class ColorTests : TestBase() {
      */
     @Test
     fun HCL_to_RGB_reference() {
-        Colors.hcl(0.deg, .0, .0).toRgb() shouldBe black
-        Colors.hcl(240.deg, .0, .0).toRgb() shouldBe black
-        Colors.hcl(126.deg, .0, .0).toRgb() shouldBe black
-        Colors.hcl(6800.deg, .0, .0).toRgb() shouldBe black
+        Colors.hcl(0.deg, .0, .0.pct).toRgb() shouldBe black
+        Colors.hcl(240.deg, .0, .0.pct).toRgb() shouldBe black
+        Colors.hcl(126.deg, .0, .0.pct).toRgb() shouldBe black
+        Colors.hcl(6800.deg, .0, .0.pct).toRgb() shouldBe black
 
-        Colors.hcl(0.deg, .0, 100.0).toRgb() shouldBe white
-        Colors.hcl(240.deg, .0, 100.0).toRgb() shouldBe white
-        Colors.hcl(126.deg, .0, 100.0).toRgb() shouldBe white
-        Colors.hcl(680.deg, .0, 100.0).toRgb() shouldBe white
+        Colors.hcl(0.deg, .0, 100.0.pct).toRgb() shouldBe white
+        Colors.hcl(240.deg, .0, 100.0.pct).toRgb() shouldBe white
+        Colors.hcl(126.deg, .0, 100.0.pct).toRgb() shouldBe white
+        Colors.hcl(680.deg, .0, 100.0.pct).toRgb() shouldBe white
 
-        Colors.hcl(32.deg, 80.0, 80.0, .0).toRgb() shouldBe Colors.rgb(0xff897c, 0.0)
-        Colors.hcl(260.deg, 20.0, 44.0, 1.0).toRgb() shouldBe Colors.rgb(0x4b6b88, 1.0)
-        Colors.hcl(300.deg, 98.0, 16.0, .3).toRgb() shouldBe Colors.rgb(0x0014a8, .3)
-        Colors.hcl(16.deg, 75.0, 23.0, .5).toRgb() shouldBe Colors.rgb(0x8f001e, .5)
+        Colors.hcl(32.deg, 80.0, 80.0.pct, 0.pct).toRgb() shouldBe RgbColor(0xff897c, 0.pct)
+        Colors.hcl(260.deg, 20.0, 44.0.pct, 100.pct).toRgb() shouldBe RgbColor(0x4b6b88, 100.pct)
+        Colors.hcl(300.deg, 98.0, 16.0.pct, 30.pct).toRgb() shouldBe RgbColor(0x0014a8, 30.pct)
+        Colors.hcl(16.deg, 75.0, 23.0.pct, 50.pct).toRgb() shouldBe RgbColor(0x8f001e, 50.pct)
 
-        Colors.hcl(580.deg, 30.0, 20.0).toRgb() shouldBe Colors.rgb(0x003a4c)
-        Colors.hcl((-200).deg, 30.0, 20.0).toRgb() shouldBe Colors.rgb(0x003a20)
-        Colors.hcl((-120).deg, 70.0, 60.0).toRgb() shouldBe Colors.rgb(0x00a6fb)
-        Colors.hcl(400.deg, 20.0, 50.0).toRgb() shouldBe Colors.rgb(0x976d62)
-        Colors.hcl(512.deg, 70.0, 20.0).toRgb() shouldBe Colors.rgb(0x003f00)
-        Colors.hcl(124.deg, 1.0, 20.0).toRgb() shouldBe Colors.rgb(0x30312f)
+        Colors.hcl(580.deg, 30.0, 20.0.pct).toRgb() shouldBe RgbColor(0x003a4c)
+        Colors.hcl((-200).deg, 30.0, 20.0.pct).toRgb() shouldBe RgbColor(0x003a20)
+        Colors.hcl((-120).deg, 70.0, 60.0.pct).toRgb() shouldBe RgbColor(0x00a6fb)
+        Colors.hcl(400.deg, 20.0, 50.0.pct).toRgb() shouldBe RgbColor(0x976d62)
+        Colors.hcl(512.deg, 70.0, 20.0.pct).toRgb() shouldBe RgbColor(0x003f00)
+        Colors.hcl(124.deg, 1.0, 20.0.pct).toRgb() shouldBe RgbColor(0x30312f)
 
-        Colors.hcl(124.deg, -240.0, 50.0).toRgb() shouldBe Colors.rgb(0x0000ff)
-        Colors.hcl(124.deg, -12.0, 50.0).toRgb() shouldBe Colors.rgb(0x7b7488)
+        Colors.hcl(124.deg, -240.0, 50.0.pct).toRgb() shouldBe RgbColor(0x0000ff)
+        Colors.hcl(124.deg, -12.0, 50.0.pct).toRgb() shouldBe RgbColor(0x7b7488)
 
         // first check HCL to LAB
-        Colors.hcl(124.deg, 63.0, .0).toLaba() shouldBe LabColor(4.4, -9.0, 6.43)
-        Colors.hcl(36.deg, 155.0, 20.0).toLaba() shouldBe LabColor(39.61, 64.32, 53.97)
-        Colors.hcl(124.deg, 63.0, -20.0).toLaba() shouldBe LabColor(.0, .0, .0)
+        Colors.hcl(124.deg, 63.0, .0.pct).toLab() shouldBe Colors.lab(4.4.pct, -9.0, 6.43)
+        Colors.hcl(36.deg, 155.0, 20.0.pct).toLab() shouldBe Colors.lab(39.61.pct, 64.32, 53.97)
+        Colors.hcl(124.deg, 63.0, -20.0.pct).toLab() shouldBe Colors.lab(.0.pct, .0, .0)
 
         // then check LAB to RGB
-        Colors.lab(4.4, -9.0, 6.43).toRgb() shouldBe Colors.rgb(0x001400)
-        Colors.lab(39.61, 64.32, 53.97).toRgb() shouldBe Colors.rgb(0xbf0000)
-        Colors.lab(.0, .0, .0).toRgb() shouldBe Colors.rgb(0x000000)
+        Colors.lab(4.4.pct, -9.0, 6.43).toRgb() shouldBe RgbColor(0x001400)
+        Colors.lab(39.61.pct, 64.32, 53.97).toRgb() shouldBe RgbColor(0xbf0000)
+        Colors.lab(.0.pct, .0, .0).toRgb() shouldBe RgbColor(0x000000)
 
         // so HCL to RGB should be ok
-        Colors.hcl(124.deg, 63.0, .0).toRgb() shouldBe Colors.rgb(0x001400)
-        Colors.hcl(36.deg, 155.0, 20.0).toRgb() shouldBe Colors.rgb(0xbf0000)
-        Colors.hcl(124.deg, 63.0, -20.0).toRgb() shouldBe Colors.rgb(0x000000)
+        Colors.hcl(124.deg, 63.0, 0.pct).toRgb() shouldBe RgbColor(0x001400)
+        Colors.hcl(36.deg, 155.0, 20.pct).toRgb() shouldBe RgbColor(0xbf0000)
+        Colors.hcl(124.deg, 63.0, -20.pct).toRgb() shouldBe RgbColor(0x000000)
     }
 
     @Test
     fun RGBA_to_HSLA_rounded() {
         //Color(0xf5cfa3, 0).toHsla() shouldBe hsla(32.deg, 0.80, 0.80, 0)
-        val color1 = Colors.rgb(0xf5cfa3, 0.0).toHsla()
+        val color1 = RgbColor(0xf5cfa3, 0.pct).toHsla()
         round(color1.h.deg) shouldBeClose 32.0
-        round(color1.s * 100) shouldBeClose 80.0
-        round(color1.l * 100) shouldBeClose 80.0
-        color1.alpha shouldBe 0.0
+        round(color1.s.value * 100) shouldBeClose 80.0
+        round(color1.l.value * 100) shouldBeClose 80.0
+        color1.alpha shouldBe 0.pct
 
 //            hsla(260.deg, 0.20, 0.44, 1).toRgba() shouldBe Color(0x695a87, 1)
-        val color2 = Colors.rgb(0x695a87, 1.0).toHsla()
+        val color2 = RgbColor(0x695a87, 100.pct).toHsla()
         round(color2.h.deg) shouldBeClose 260.0
-        round(color2.s * 100) shouldBeClose 20.0
-        round(color2.l * 100) shouldBeClose 44.0
-        color2.alpha shouldBe 1.0
+        round(color2.s.value * 100) shouldBeClose 20.0
+        round(color2.l.value * 100) shouldBeClose 44.0
+        color2.alpha shouldBe 100.pct
 
 //            hsla(300.deg, 0.98, 0.16, .3).toRgba() shouldBe Color(0x510151, .3)
-        val color3 = Colors.rgb(0x510151, .3).toHsla()
+        val color3 = RgbColor(0x510151, 30.pct).toHsla()
         round(color3.h.deg) shouldBeClose 300.0
-        round(color3.s * 100) shouldBeClose 98.0
-        round(color3.l * 100) shouldBeClose 16.0
-        color3.alpha shouldBe .3
+        round(color3.s.value * 100) shouldBeClose 98.0
+        round(color3.l.value * 100) shouldBeClose 16.0
+        color3.alpha shouldBe 30.pct
 
 //            hsla(16.deg, 0.75, 0.23, .5).toRgba() shouldBe Color(0x67260f, .5)*/
-        val color4 = Colors.rgb(0x67260f, .5).toHsla()
+        val color4 = RgbColor(0x67260f, 50.pct).toHsla()
         round(color4.h.deg) shouldBeClose 16.0
-        round(color4.s * 100) shouldBeClose 75.0
-        round(color4.l * 100) shouldBeClose 23.0
-        color4.alpha shouldBe .5
+        round(color4.s.value * 100) shouldBeClose 75.0
+        round(color4.l.value * 100) shouldBeClose 23.0
+        color4.alpha shouldBe 50.pct
 
 //            hsla(0.deg, 0, 0, .42).toRgba() shouldBe Color(0x6a6a6a, .2)*/
-        val color5 = Colors.rgb(0x6a6a6a, .2).toHsla()
+        val color5 = RgbColor(0x6a6a6a, 20.pct).toHsla()
         round(color5.h.deg) shouldBeClose 0.0
-        round(color5.s * 100) shouldBeClose 0.0
-        round(color5.l * 100) shouldBeClose 42.0
-        color5.alpha shouldBe .2
+        round(color5.s.value * 100) shouldBeClose 0.0
+        round(color5.l.value * 100) shouldBeClose 42.0
+        color5.alpha shouldBe 20.pct
     }
 
     @Test
     fun RGBA_to_LAB_rounded() {
 
-        val color1 = Colors.rgb(0xf5cfa3, 0.0).toLaba()
-        round(color1.labL) shouldBe 85.0
+        val color1 = RgbColor(0xf5cfa3, 0.pct).toLab()
+        round(color1.labL.value * 100) shouldBe 85.0
         round(color1.labA) shouldBe 7.0
         round(color1.labB) shouldBe 27.0
-        color1.alpha shouldBe 0.0
+        color1.alpha shouldBe 0.pct
 
-        val color2 = Colors.rgb(0x695a87, 1.0).toLaba()
-        round(color2.labL) shouldBe 41.0
+        val color2 = RgbColor(0x695a87, 100.pct).toLab()
+        round(color2.labL.value * 100) shouldBe 41.0
         round(color2.labA) shouldBe 16.0
         round(color2.labB) shouldBe -23.0
-        color2.alpha shouldBe 1.0
+        color2.alpha shouldBe 100.pct
 
-        val color3 = Colors.rgb(0x510151, .3).toLaba()
-        round(color3.labL) shouldBe 17.0
+        val color3 = RgbColor(0x510151, 30.pct).toLab()
+        round(color3.labL.value * 100) shouldBe 17.0
         round(color3.labA) shouldBe 42.0
         round(color3.labB) shouldBe -26.0
-        color3.alpha shouldBe .3
+        color3.alpha shouldBe 30.pct
 
-        val color4 = Colors.rgb(0x67260f, .5).toLaba()
-        round(color4.labL) shouldBe 25.0
+        val color4 = RgbColor(0x67260f, 50.pct).toLab()
+        round(color4.labL.value * 100) shouldBe 25.0
         round(color4.labA) shouldBe 28.0
         round(color4.labB) shouldBe 29.0
-        color4.alpha shouldBe .5
+        color4.alpha shouldBe 50.pct
 
-        val color5 = Colors.rgb(0x6a6a6a, .2).toLaba()
-        round(color5.labL) shouldBe 45.0
+        val color5 = RgbColor(0x6a6a6a, 20.pct).toLab()
+        round(color5.labL.value * 100) shouldBe 45.0
         round(color5.labA) shouldBe -0.0
         round(color5.labB) shouldBe 0.0
-        color5.alpha shouldBe .2
+        color5.alpha shouldBe 20.pct
 
-        val color6 = white.toLaba()
-        round(color6.labL) shouldBe 100.0
+        val color6 = white.toLab()
+        round(color6.labL.value * 100) shouldBe 100.0
         round(color6.labA).absoluteValue shouldBe 0.0
         round(color6.labB) shouldBe 0.0
 
-        val color7 = black.toLaba()
-        round(color7.labL) shouldBeClose 0.0         // give -0 in JVM
+        val color7 = black.toLab()
+        round(color7.labL.value * 100) shouldBeClose 0.0         // give -0 in JVM
         round(color7.labA) shouldBe 0.0
         round(color7.labB) shouldBe 0.0
     }
 
     @Test
     fun HSL_REFERENCES_HSL_0_0_0_should_be_black() {
-        black.toHsla() shouldBe Colors.hsl(0.deg, 0.0, 0.0)
-        white.toHsla() shouldBe Colors.hsl(0.deg, 0.0, 1.0)
+        black.toHsla() shouldBe Colors.hsl(0.deg, 0.pct, 0.pct)
+        white.toHsla() shouldBe Colors.hsl(0.deg, 0.pct, 100.pct)
 
-        Colors.hsl(Angle(0.0), 0.0, 0.0).toRgb() shouldBe black
-        Colors.hsl(Angle(0.0), 0.0, 1.0).toRgb() shouldBe white
+        Colors.hsl(Angle(0.0), 0.pct, 0.pct).toRgb() shouldBe black
+        Colors.hsl(Angle(0.0), 0.pct, 100.pct).toRgb() shouldBe white
     }
 
 // no more default color
@@ -237,30 +238,30 @@ class ColorTests : TestBase() {
 
     @Test
     fun RGB_conversion_of_multiples_HSL_colors() {
-        Colors.hsl(0.deg, 0.0, 0.742).toRgb().rgbHex shouldBe "#bdbdbd"
-        Colors.hsl(120.deg, 0.5, 0.5).toRgb().rgbHex shouldBe "#40bf40"
-        Colors.hsl(180.deg, 0.3, 0.6).toRgb().rgbHex shouldBe "#7ab8b8"
-        Colors.hsl(63.deg, 0.22, 0.46).toRgb().rgbHex shouldBe "#8d8f5b"
-        Colors.hsl(32.0.deg, 0.8, 0.8).toRgb().rgbHex shouldBe "#f5cfa3"
-        Colors.hsl(272.deg, 0.56, 0.67).toRgb().rgbHex shouldBe "#ae7cda"
-        Colors.hsl(300.deg, 0.2, 0.4).toRgb().rgbHex shouldBe "#7a527a"
-        Colors.hsl(265.deg, 0.51, 0.42).toRgb().rgbHex shouldBe "#6234a2"
-        Colors.hsl(300.deg, 1.0, 0.5).toRgb().rgbHex shouldBe "#ff00ff"
-        Colors.hsl(208.deg, 1.0, 0.9705882).toRgb().rgbHex shouldBe aliceblue.rgbHex
+        Colors.hsl(0.deg, 0.pct, 74.2.pct).toRgb().rgbHex shouldBe "#bdbdbd"
+        Colors.hsl(120.deg, 50.pct, 50.pct).toRgb().rgbHex shouldBe "#40bf40"
+        Colors.hsl(180.deg, 30.pct, 60.pct).toRgb().rgbHex shouldBe "#7ab8b8"
+        Colors.hsl(63.deg, 22.pct, 46.pct).toRgb().rgbHex shouldBe "#8d8f5b"
+        Colors.hsl(32.0.deg, 80.pct, 80.pct).toRgb().rgbHex shouldBe "#f5cfa3"
+        Colors.hsl(272.deg, 56.pct, 67.pct).toRgb().rgbHex shouldBe "#ae7cda"
+        Colors.hsl(300.deg, 20.pct, 40.pct).toRgb().rgbHex shouldBe "#7a527a"
+        Colors.hsl(265.deg, 51.pct, 42.pct).toRgb().rgbHex shouldBe "#6234a2"
+        Colors.hsl(300.deg, 100.pct, 50.pct).toRgb().rgbHex shouldBe "#ff00ff"
+        Colors.hsl(208.deg, 100.pct, 97.05882.pct).toRgb().rgbHex shouldBe aliceblue.rgbHex
     }
 
     @Test
     fun RGB_conversion_of_HSL_120_05_05_05f_should_be_40BF40_with_05_alpha() {
-        val color = Colors.hsl(120.deg, 0.5, 0.5, 0.5).toRgb()
+        val color = Colors.hsl(120.deg, 50.pct, 50.pct, 50.pct).toRgb()
         color.rgbHex shouldBe "#40bf40"
-        color.alpha shouldBe 0.5
+        color.alpha shouldBe 50.pct
     }
 
     @Test
     fun HSL_coercing_under_0_and_over_1_luminance() {
-        Colors.hsl(488.deg, .5, .5).toRgb() shouldBe Colors.hsl(128.deg, .5, .5).toRgb()
-        Colors.hsl(120.deg, -.5, .5) shouldBe Colors.hsl(120.deg, .0, .5)
-        Colors.hsl(120.deg, .5, 1.5) shouldBe Colors.hsl(120.deg, .5, 1.0)
+        Colors.hsl(488.deg, 50.pct, 50.pct).toRgb() shouldBe Colors.hsl(128.deg, 50.pct, 50.pct).toRgb()
+        Colors.hsl(120.deg, -50.pct, 50.pct) shouldBe Colors.hsl(120.deg, 0.pct, 50.pct)
+        Colors.hsl(120.deg, 50.pct, 150.pct) shouldBe Colors.hsl(120.deg, 50.pct, 100.pct)
     }
 
 // no more default color
@@ -271,96 +272,93 @@ class ColorTests : TestBase() {
 
     @Test
     fun RGB_conversion_of_multiples_LAB_colors() {
-        Colors.lab(76.61, 0.0, .0).toRgb().rgbHex shouldBe "#bdbdbd"
-        Colors.lab(68.55, -58.98, 52.11).toRgb().rgbHex shouldBe "#40bf40"
-        Colors.lab(70.79, -19.78, -6.34).toRgb().rgbHex shouldBe "#7ab8b8"
-        Colors.lab(58.10, -9.19, 27.46).toRgb().rgbHex shouldBe "#8d8f5b"
-        Colors.lab(85.34, 7.23, 26.85).toRgb().rgbHex shouldBe "#f5cfa3"
-        Colors.lab(60.32, 37.18, -40.92).toRgb().rgbHex shouldBe "#ae7cda"
-        Colors.lab(40.54, 23.82, -15.98).toRgb().rgbHex shouldBe "#7a527a"
-        Colors.lab(33.27, 43.84, -52.04).toRgb().rgbHex shouldBe "#6234a2"
-        val color = Colors.lab(68.54923, -58.98131, 52.11442, 0.5).toRgb()
+        Colors.lab(76.61.pct, 0.0, .0).toRgb().rgbHex shouldBe "#bdbdbd"
+        Colors.lab(68.55.pct, -58.98, 52.11).toRgb().rgbHex shouldBe "#40bf40"
+        Colors.lab(70.79.pct, -19.78, -6.34).toRgb().rgbHex shouldBe "#7ab8b8"
+        Colors.lab(58.10.pct, -9.19, 27.46).toRgb().rgbHex shouldBe "#8d8f5b"
+        Colors.lab(85.34.pct, 7.23, 26.85).toRgb().rgbHex shouldBe "#f5cfa3"
+        Colors.lab(60.32.pct, 37.18, -40.92).toRgb().rgbHex shouldBe "#ae7cda"
+        Colors.lab(40.54.pct, 23.82, -15.98).toRgb().rgbHex shouldBe "#7a527a"
+        Colors.lab(33.27.pct, 43.84, -52.04).toRgb().rgbHex shouldBe "#6234a2"
+        val color = Colors.lab(68.54923.pct, -58.98131, 52.11442, 50.pct).toRgb()
         color.rgbHex shouldBe "#40bf40"
-        color.alpha shouldBe 0.5
+        color.alpha shouldBe 50.pct
     }
 
+    // TODO do not round, use shouldBeClose + more precise values
     @Test
     fun RGB_to_LAB_to_HCL_checks_for_multiple_colors() {
-        val color1 = Colors.rgb(0xf5cfa3, 0.0).toLaba().toHcla()
+        val color1 = RgbColor(0xf5cfa3, 0.pct).toLab().toHcla()
         round(color1.h.deg) shouldBeClose 75.0
         round(color1.c) shouldBeClose 28.0
-        round(color1.l) shouldBe 85.0
-        color1.alpha shouldBe 0.0
-        color1 shouldBe Colors.rgb(0xf5cfa3, 0.0).toHcl()
+        round(color1.l.value * 100) shouldBe 85.0
+        color1.alpha shouldBe 0.pct
 
-        val color2 = Colors.rgb(0x695a87, 1.0).toLaba().toHcla()
+        val color2 = RgbColor(0x695a87, 100.pct).toLab().toHcla()
         round(color2.h.deg) shouldBeClose 305.0
         round(color2.c) shouldBeClose 28.0
-        round(color2.l) shouldBe 41.0
-        color2.alpha shouldBe 1.0
-        color2 shouldBe Colors.rgb(0x695a87, 1.0).toHcl()
+        round(color2.l.value * 100) shouldBe 41.0
+        color2.alpha shouldBe 100.pct
 
-        val color3 = Colors.rgb(0x510151, .3).toLaba().toHcla()
+        val color3 = RgbColor(0x510151, 50.pct).toLab().toHcla()
         round(color3.h.deg) shouldBeClose 328.0
         round(color3.c) shouldBeClose 50.0
-        round(color3.l) shouldBe 17.0
-        color3.alpha shouldBe .3
-        color3 shouldBe Colors.rgb(0x510151, .3).toHcl()
+        round(color3.l.value * 100) shouldBe 17.0
+        color3.alpha shouldBe 50.pct
 
-        val color4 = Colors.rgb(0x67260f, .5).toLaba().toHcla()
+        val color4 = RgbColor(0x67260f, 30.pct).toLab().toHcla()
         round(color4.h.deg) shouldBeClose 46.0
         round(color4.c) shouldBeClose 40.0
-        round(color4.l) shouldBe 25.0
-        color4.alpha shouldBe .5
+        round(color4.l.value * 100) shouldBe 25.0
+        color4.alpha shouldBe 30.pct
 
-        val color5 = Colors.rgb(0x6a6a6a, .2).toLaba().toHcla()
+        val color5 = RgbColor(0x6a6a6a, 20.pct).toLab().toHcla()
         //round(color5.h.deg) shouldBe 267                     // achromatic, hue value irrelevant
         round(color5.c) shouldBeClose 0.0
-        round(color5.l) shouldBe 45.0
-        color5.alpha shouldBe .2
+        round(color5.l.value * 100) shouldBe 45.0
+        color5.alpha shouldBe 20.pct
 
-        val color6 = white.toLaba().toHcla()
+        val color6 = white.toLab().toHcla()
         //round(color6.h.deg) shouldBeClose 267                     // achromatic, hue value irrelevant
         round(color6.c) shouldBeClose 0.0
-        round(color6.l) shouldBe 100.0
+        round(color6.l.value * 100) shouldBe 100.0
 
-        val color7 = black.toLaba().toHcla()
+        val color7 = black.toLab().toHcla()
         //round(color7.h.deg) shouldBe 0                       // achromatic, hue value irrelevant
         round(color7.c) shouldBeClose 0.0
-        round(color7.l) shouldBe 0.0
+        round(color7.l.value * 100) shouldBe 0.0
     }
 
     @Test
     fun HCL_to_LAB_to_RGB_checks_for_multiple_colors() {
-        val color1 = Colors.hcl(75.deg, 28.0, 85.0, .0).toLaba().toRgb()
+        val color1 = Colors.hcl(75.deg, 28.0, 85.pct, 0.pct).toLab().toRgb()
         color1.rgbHex shouldBe "#f4cea2"
-        color1.alpha shouldBe 0.0
-        color1 shouldBe Colors.hcl(75.deg, 28.0, 85.0, .0).toRgb()
+        color1.alpha shouldBe 0.pct
 
-        val color2 = Colors.hcl(305.deg, 28.0, 41.0, .0).toLaba().toRgb()
+        val color2 = Colors.hcl(305.deg, 28.0, 41.pct, 0.pct).toLab().toRgb()
         color2.rgbHex shouldBe "#685986"
-        color2.alpha shouldBe .0
-        color2 shouldBe Colors.hcl(305.deg, 28.0, 41.0, .0).toRgb()
+        color2.alpha shouldBe 0.pct
 
-        val color3 = Colors.hcl(328.deg, 50.0, 17.0, .3).toLaba().toRgb()
+        val color3 = Colors.hcl(328.deg, 50.0, 17.pct, 30.pct).toLab().toRgb()
         color3.rgbHex shouldBe "#500051"
-        color3.alpha shouldBe .3
-        color3 shouldBe Colors.hcl(328.deg, 50.0, 17.0, .3).toRgb()
+        color3.alpha shouldBe 30.pct
 
-        val color4 = Colors.hcl(46.deg, 40.0, 25.0, .5).toLaba().toRgb()
+        val color4 = Colors.hcl(46.deg, 40.0, 25.pct, 50.pct).toLab().toRgb()
         color4.rgbHex shouldBe "#682710"
-        color4.alpha shouldBe .5
+        color4.alpha shouldBe 50.pct
 
-        val color5 = Colors.hcl(267.deg, 0.0, 45.0, .5).toLaba().toRgb()
+        val color5 = Colors.hcl(267.deg, 0.0, 45.pct, 50.pct).toLab().toRgb()
         color5.rgbHex shouldBe "#6a6a6a"
-        color5.alpha shouldBe .5
+        color5.alpha shouldBe 50.pct
 
-        val color6 = Colors.hcl(0.deg, 0.0, 100.0).toLaba().toRgb()
+        val color6 = Colors.hcl(0.deg, 0.0, 100.pct).toLab().toRgb()
         color6.rgbHex shouldBe "#ffffff"
 
-        val color7 = Colors.hcl(0.deg, 0.0, 0.0).toLaba().toRgb()
+        val color7 = Colors.hcl(0.deg, 0.0, 0.pct).toLab().toRgb()
         color7.rgbHex shouldBe "#000000"
     }
+
+    // TODO check brighten and darken for HCL and LAB color !! seems wrong
 
     @Test
     fun brighten_RGB() {
@@ -378,6 +376,21 @@ class ColorTests : TestBase() {
     }
 
     @Test
+    fun brighten_HCL() {
+        hotpink.toLab().toHcla().brighten().rgbHex shouldBe "#ff9ce6"
+        hotpink.toLab().toHcla().brighten(2.0).rgbHex shouldBe "#ffd1ff"
+        hotpink.toLab().toHcla().brighten(3.0).rgbHex shouldBe "#ffffff"
+
+        darkseagreen.toLab().toHcla().brighten().rgbHex shouldBe "#c0efbf"
+        darkseagreen.toLab().toHcla().brighten(2.0).rgbHex shouldBe "#f3fff2"
+        darkseagreen.toLab().toHcla().brighten(3.0).rgbHex shouldBe "#ffffff"
+
+        teal.toLab().toHcla().brighten().rgbHex shouldBe "#4cb0af"
+        teal.toLab().toHcla().brighten(2.0).rgbHex shouldBe "#81e2e1"
+        teal.toLab().toHcla().brighten(3.0).rgbHex shouldBe "#b5ffff"
+    }
+
+    @Test
     fun darken_RGB() {
         hotpink.darken().rgbHex shouldBe "#c93384"
         hotpink.darken(2.0).rgbHex shouldBe "#930058"
@@ -390,6 +403,21 @@ class ColorTests : TestBase() {
         teal.darken().rgbHex shouldBe "#005354"
         teal.darken(2.0).rgbHex shouldBe "#00292b"
         teal.darken(2.6).rgbHex shouldBe "#001715"
+    }
+
+    @Test
+    fun darken_HCL() {
+        hotpink.toLab().toHcla().darken().rgbHex shouldBe "#c93384"
+        hotpink.toLab().toHcla().darken(2.0).rgbHex shouldBe "#930058"
+        hotpink.toLab().toHcla().darken(2.6).rgbHex shouldBe "#74003f"
+
+        darkseagreen.toLab().toHcla().darken().rgbHex shouldBe "#608c61"
+        darkseagreen.toLab().toHcla().darken(2.0).rgbHex shouldBe "#345e37"
+        darkseagreen.toLab().toHcla().darken(2.6).rgbHex shouldBe "#1b441f"
+
+        teal.toLab().toHcla().darken().rgbHex shouldBe "#005354"
+        teal.toLab().toHcla().darken(2.0).rgbHex shouldBe "#00292b"
+        teal.toLab().toHcla().darken(2.6).rgbHex shouldBe "#001715"
     }
 
     @Test
@@ -432,19 +460,19 @@ class ColorTests : TestBase() {
     fun linear_gradient_builder() {
         val builder = Colors.Gradient.linear(Point(.0, .0), Point(100.0, .0))
 
-        val gradient = builder.withColor(aliceblue, .0).andColor(darkseagreen, .6)
+        val gradient = builder.withColor(aliceblue, 0.pct).andColor(darkseagreen, 60.pct)
         gradient.colorStops.size shouldBe 2
 
-        gradient.andColor(hotpink, 1.0).colorStops.size shouldBe 3
+        gradient.andColor(hotpink, 100.pct).colorStops.size shouldBe 3
     }
 
     @Test
     fun radial_gradient_builder() {
         val builder = Colors.Gradient.radial(Point(.0, .0), 100.0)
 
-        val gradient = builder.withColor(aliceblue, .0).andColor(darkseagreen, .6)
+        val gradient = builder.withColor(aliceblue, 0.pct).andColor(darkseagreen, 60.pct)
         gradient.colorStops.size shouldBe 2
 
-        gradient.andColor(hotpink, 1.0).colorStops.size shouldBe 3
+        gradient.andColor(hotpink, 100.pct).colorStops.size shouldBe 3
     }
 }

--- a/examples/ex-chord/ex-chord-common/src/main/kotlin/ChordCommon.kt
+++ b/examples/ex-chord/ex-chord-common/src/main/kotlin/ChordCommon.kt
@@ -9,6 +9,8 @@ import io.data2viz.color.*
 import io.data2viz.geom.Path
 import io.data2viz.geom.Point
 import io.data2viz.geom.Size
+import io.data2viz.math.Percent
+import io.data2viz.math.pct
 import io.data2viz.shape.arcBuilder
 import io.data2viz.viz.Viz
 import io.data2viz.viz.viz
@@ -89,7 +91,7 @@ fun chordViz(): Viz = viz {
         //drawing ribbons
         avengersChords.chords.forEach { chord ->
             path {
-                style.fill = chord.toGradient(.6)
+                style.fill = chord.toGradient(60.pct)
                 style.stroke = null
                 ribbon(chord, this)
             }
@@ -99,7 +101,7 @@ fun chordViz(): Viz = viz {
 
 
 //Todo Move in API
-fun Chord.toGradient(alpha:Double) = Colors.Gradient.linear(
+fun Chord.toGradient(alpha:Percent) = Colors.Gradient.linear(
     Point(
         inner * cos((source.endAngle - source.startAngle) / 2 + source.startAngle - PI / 2),
         inner * sin((source.endAngle - source.startAngle) / 2 + source.startAngle - PI / 2)

--- a/examples/ex-line-of-sight/ex-line-of-sight-common/src/main/kotlin/io/data2viz/examples/lineOfSight/LineOfSightView.kt
+++ b/examples/ex-line-of-sight/ex-line-of-sight-common/src/main/kotlin/io/data2viz/examples/lineOfSight/LineOfSightView.kt
@@ -2,6 +2,7 @@ package io.data2viz.examples.lineOfSight
 
 import io.data2viz.color.*
 import io.data2viz.geom.Polygon
+import io.data2viz.math.pct
 import io.data2viz.viz.Viz
 import io.data2viz.viz.viz
 
@@ -85,12 +86,12 @@ fun lineOfSightViz(): Viz = viz {
 private fun lightGradient(): RadialGradient {
     val lightColor = 0xFFFFFF.col
     val fromColor = 0xFFFF00.col
-    val endColor = Colors.rgb(0xFFFF00, 0.0)
+    val endColor = Colors.rgb(0xFFFF00, 0.pct)
     return Colors.Gradient.radial(model.lightPos, .7 * vizWidth)
-        .withColor(lightColor, .0)
-        .andColor(lightColor, .01)
-        .andColor(fromColor, .02)
-        .andColor(endColor, 1.0)
+        .withColor(lightColor, 0.pct)
+        .andColor(lightColor, 1.pct)
+        .andColor(fromColor, 2.pct)
+        .andColor(endColor, 100.pct)
 }
 
 

--- a/examples/ex-sankey/ex-sankey-common/src/main/kotlin/SankeyCommon.kt
+++ b/examples/ex-sankey/ex-sankey-common/src/main/kotlin/SankeyCommon.kt
@@ -2,6 +2,7 @@ package io.data2viz.examples.sankey
 
 import io.data2viz.color.Colors
 import io.data2viz.geom.Point
+import io.data2viz.math.pct
 import io.data2viz.sankey.SankeyAlignment
 import io.data2viz.sankey.SankeyLayout
 import io.data2viz.sankey.sankeyLinkHorizontal
@@ -155,8 +156,8 @@ fun GroupNode.buildSankey() {
             )
         )
             //Set the starting color (at 0%)
-            .withColor(fills(link.source.index % 20).withAlpha(.6))
-            .andColor(fills(link.target.index % 20).withAlpha(.6))
+            .withColor(fills(link.source.index % 20).withAlpha(60.pct))
+            .andColor(fills(link.target.index % 20).withAlpha(60.pct))
 
         path {
             style.stroke = gradient

--- a/interpolate/d2v-interpolate-common/src/main/kotlin/io/data2viz/interpolate/hcl.kt
+++ b/interpolate/d2v-interpolate-common/src/main/kotlin/io/data2viz/interpolate/hcl.kt
@@ -15,9 +15,9 @@ private fun interpolateHcl(start: Color, end:Color, long:Boolean): Interpolator<
 
     val h = interpolateHue(startHCL.h, endHCL.h, long)
     val c = colorInterpolator(startHCL.c, endHCL.c)
-    val l = colorInterpolator(startHCL.l, endHCL.l)
+    val l = colorInterpolator(startHCL.l.value, endHCL.l.value)
 
-    return fun(percent:Percent) = Colors.hcl(Angle(h(percent)), c(percent), l(percent))
+    return fun(percent:Percent) = Colors.hcl(Angle(h(percent)), c(percent), Percent(l(percent)))
 }
 
 fun hclLongInterpolator(start:Color, end: Color) = interpolateHcl(start, end, long = true)

--- a/interpolate/d2v-interpolate-common/src/main/kotlin/io/data2viz/interpolate/hsl.kt
+++ b/interpolate/d2v-interpolate-common/src/main/kotlin/io/data2viz/interpolate/hsl.kt
@@ -16,10 +16,10 @@ private fun interpolateHsl(start: Color, end:Color, long:Boolean): Interpolator<
     if (endHSL.isAchromatic()) endHSL = Colors.hsl(startHSL.h, startHSL.s, endHSL.l, endHSL.alpha)
 
     val h = interpolateHue(startHSL.h, endHSL.h, long)
-    val s = colorInterpolator(startHSL.s, endHSL.s)
-    val l = colorInterpolator(startHSL.l, endHSL.l)
+    val s = colorInterpolator(startHSL.s.value, endHSL.s.value)
+    val l = colorInterpolator(startHSL.l.value, endHSL.l.value)
 
-    return fun(percent:Percent) = Colors.hsl(Angle(h(percent)), s(percent), l(percent))
+    return fun(percent:Percent) = Colors.hsl(Angle(h(percent)), Percent(s(percent)), Percent(l(percent)))
 }
 
 /*fun uninterpolateHsl(start:HSL, end:HSL, long:Boolean): (HSL) -> Double {

--- a/interpolate/d2v-interpolate-common/src/main/kotlin/io/data2viz/interpolate/lab.kt
+++ b/interpolate/d2v-interpolate-common/src/main/kotlin/io/data2viz/interpolate/lab.kt
@@ -10,11 +10,11 @@ private fun interpolateLab(start: Color, end:Color): Interpolator<Color> {
     val endLab = end.toLab()
     val colorInterpolator = gamma()
 
-    val l = colorInterpolator(startLab.labL, endLab.labL)
+    val l = colorInterpolator(startLab.labL.value, endLab.labL.value)
     val a = colorInterpolator(startLab.labA, endLab.labA)
     val b = colorInterpolator(startLab.labB, endLab.labB)
 
-    return fun(percent:Percent) = Colors.lab(l(percent), a(percent), b(percent))
+    return fun(percent:Percent) = Colors.lab(Percent(l(percent)), a(percent), b(percent))
 }
 
 fun labInterpolator(start:Color, end:Color) = interpolateLab(start, end)

--- a/interpolate/d2v-interpolate-common/src/test/kotlin/io.data2viz.interpolate/HSLTests.kt
+++ b/interpolate/d2v-interpolate-common/src/test/kotlin/io.data2viz.interpolate/HSLTests.kt
@@ -12,7 +12,7 @@ class HSLTests : TestBase() {
         val iterator = hslInterpolator(Colors.Web.teal, Colors.Web.pink)
         iterator(-100.pct) shouldBe Colors.Web.teal
         iterator(0.pct) shouldBe Colors.Web.teal
-        iterator(13.pct) shouldBe Colors.rgb(0x006ba9, 1.0)
+        iterator(13.pct) shouldBe Colors.rgb(0x006ba9, 100.pct)
         iterator(25.pct) shouldBe Colors.rgb(0x003dd0)
         iterator(50.pct) shouldBe Colors.rgb(0x7c21ff)
         iterator(60.pct) shouldBe Colors.rgb(0xc540ff)
@@ -24,26 +24,26 @@ class HSLTests : TestBase() {
     @Test
     // TODO : test in D3 when the 2 colors delta is < 180.deg... here will produce same interpolation as HSLShort...
     fun HSLShortInterpolation() {
-        val start = Colors.hsl(300.deg, 1.0, .25)
-        val end = Colors.hsl(38.deg, 1.0, .5)
+        val start = Colors.hsl(300.deg, 100.pct, 25.pct)
+        val end = Colors.hsl(38.deg, 100.pct, 50.pct)
         val iterator = hslInterpolator(start, end)
         iterator(-100.pct) shouldBe start
         iterator(0.pct) shouldBe start
-        iterator(50.pct) shouldBe Colors.hsl(349.deg, 1.0, 0.375)
+        iterator(50.pct) shouldBe Colors.hsl(349.deg, 100.pct, 37.5.pct)
         iterator(100.pct) shouldBe end
         iterator(200.pct) shouldBe end
     }
 
     @Test
     fun HSLLongInterpolation() {
-        val start = Colors.hsl(300.deg, 1.0, .25)
-        val end = Colors.hsl(38.deg, 1.0, .5)
+        val start = Colors.hsl(300.deg, 100.pct, 25.pct)
+        val end = Colors.hsl(38.deg, 100.pct, 50.pct)
         val iterator = hslLongInterpolator(start, end)
         iterator(-100.pct) shouldBe start
         iterator(0.pct) shouldBe start
-//        iterator(13.pct) shouldBe Colors.rgb(0x006ba9, 1.0)
+//        iterator(13.pct) shouldBe Colors.rgb(0x006ba9, 100.pct)
 //        iterator(25.pct) shouldBe Colors.rgb(0x003dd0)
-        iterator(50.pct) shouldBe Colors.hsl(169.deg, 1.0, 0.375)
+        iterator(50.pct) shouldBe Colors.hsl(169.deg, 100.pct, 37.5.pct)
 //        iterator(60.pct) shouldBe Colors.rgb(0xc540ff)
 //        iterator(75.pct) shouldBe Colors.rgb(0xff70ee)
         iterator(100.pct) shouldBe end

--- a/interpolate/d2v-interpolate-js/src/test/kotlin/io/data2viz/interpolate/HSLTestsJS.kt
+++ b/interpolate/d2v-interpolate-js/src/test/kotlin/io/data2viz/interpolate/HSLTestsJS.kt
@@ -16,7 +16,7 @@ class HSLTestsJS : TestBase() {
     @Test
     fun hslShortLinearInterpolation() {
 
-        val iterator = hslInterpolator(Colors.hsl(300.deg, 1.0, .25), Colors.hsl(38.deg, 1.0, .5))
+        val iterator = hslInterpolator(Colors.hsl(300.deg, 100.pct, 25.pct), Colors.hsl(38.deg, 100.pct, 50.pct))
         displaySmallGradient("HslColor", iterator, 888, imageReference = "http://data2viz.io/img/hsl.png")
         iterator(50.pct).toRgb().rgbHex shouldBe 0xbf0023.col.rgbHex
     }
@@ -26,7 +26,7 @@ class HSLTestsJS : TestBase() {
      */
     @Test
     fun hslLongLinearInterpolation() {
-        val iterator = hslLongInterpolator(Colors.hsl(300.deg, 1.0, .25), Colors.hsl(38.deg, 1.0, .5))
+        val iterator = hslLongInterpolator(Colors.hsl(300.deg, 100.pct, 25.pct), Colors.hsl(38.deg, 100.pct, 50.pct))
         displaySmallGradient("HslColor Long", iterator, 888, imageReference = "http://data2viz.io/img/hslLong.png")
         iterator(50.pct).toRgb().rgbHex shouldBe 0x00bf9c.col.rgbHex
     }
@@ -36,7 +36,7 @@ class HSLTestsJS : TestBase() {
      */
     @Test
     fun hslShortLinea() {
-        val iterator = hslInterpolator(Colors.hsl(38.deg, 1.0, .5), Colors.hsl(300.deg, 1.0, .25))
+        val iterator = hslInterpolator(Colors.hsl(38.deg, 100.pct, 50.pct), Colors.hsl(300.deg, 100.pct, 25.pct))
         displaySmallGradient("HslColor Reverse", iterator, 888, imageReference = "http://data2viz.io/img/hslReverse.png")
         iterator(50.pct).toRgb().rgbHex shouldBe 0xbf0023.col.rgbHex
     }
@@ -46,7 +46,7 @@ class HSLTestsJS : TestBase() {
      */
     @Test
     fun hslLongLinearInterpol() {
-        val iterator = hslLongInterpolator(Colors.hsl(38.deg, 1.0, .5), Colors.hsl(300.deg, 1.0, .25))
+        val iterator = hslLongInterpolator(Colors.hsl(38.deg, 100.pct, 50.pct), Colors.hsl(300.deg, 100.pct, 25.pct))
         displaySmallGradient(
             "HslColor Long Reverse",
             iterator,

--- a/scale/d2v-scale-common/src/test/kotlin/io/data2viz/scale/ScaleLinearTests.kt
+++ b/scale/d2v-scale-common/src/test/kotlin/io/data2viz/scale/ScaleLinearTests.kt
@@ -2,6 +2,7 @@ package io.data2viz.scale
 
 import io.data2viz.color.Colors
 import io.data2viz.math.deg
+import io.data2viz.math.pct
 import io.data2viz.test.TestBase
 import io.data2viz.test.shouldThrow
 import kotlin.test.Test
@@ -267,10 +268,10 @@ class ScaleLinearTests : TestBase() {
         val scale = ScalesChromatic.Continuous.linearHSL()
 
         scale.domain = listOf(.0, 100.0)
-        scale.range = listOf(Colors.hsl(0.deg, 1.0, 1.0), Colors.hsl(180.deg, 1.0, 1.0))
-        scale(50.0) shouldBe Colors.hsl(90.deg, 1.0, 1.0)
-        scale(20.0) shouldBe Colors.hsl(36.deg, 1.0, 1.0)
-        scale(90.0) shouldBe Colors.hsl(162.deg, 1.0, 1.0)
+        scale.range = listOf(Colors.hsl(0.deg, 100.pct, 100.pct), Colors.hsl(180.deg, 100.pct, 100.pct))
+        scale(50.0) shouldBe Colors.hsl(90.deg, 100.pct, 100.pct)
+        scale(20.0) shouldBe Colors.hsl(36.deg, 100.pct, 100.pct)
+        scale(90.0) shouldBe Colors.hsl(162.deg, 100.pct, 100.pct)
     }
 
     /////////////// TESTS /////////////////////////////////////////

--- a/viz/d2v-viz-android/src/main/java/io/data2viz/viz/AndroidColorOrGradientRenderer.kt
+++ b/viz/d2v-viz-android/src/main/java/io/data2viz/viz/AndroidColorOrGradientRenderer.kt
@@ -29,7 +29,7 @@ private fun RadialGradient.toRadialGradient(renderer: AndroidCanvasRenderer) =
 			cy.dp,
 			radius.dp,
 			IntArray(colorStops.size) { colorStops[it].color.toColor() },
-			FloatArray(colorStops.size) { colorStops[it].percent.toFloat() },
+			FloatArray(colorStops.size) { colorStops[it].percent.value.toFloat() },
 			Shader.TileMode.CLAMP)
 	}
 
@@ -42,7 +42,7 @@ private fun LinearGradient.toLinearGradient(renderer: AndroidCanvasRenderer) =
 			x2.dp,
 			y2.dp,
 			IntArray(colorStops.size) { colorStops[it].color.toColor() },
-			FloatArray(colorStops.size) { colorStops[it].percent.toFloat() },
+			FloatArray(colorStops.size) { colorStops[it].percent.value.toFloat() },
 			Shader.TileMode.CLAMP)
 	}
 

--- a/viz/d2v-viz-android/src/main/java/io/data2viz/viz/AndroidColorOrGradientRenderer.kt
+++ b/viz/d2v-viz-android/src/main/java/io/data2viz/viz/AndroidColorOrGradientRenderer.kt
@@ -47,7 +47,7 @@ private fun LinearGradient.toLinearGradient(renderer: AndroidCanvasRenderer) =
 	}
 
 fun Color.toColor() =
-	((255 * this.alpha).toInt() and 0xff shl 24) or
+	((255 * this.alpha.value).toInt() and 0xff shl 24) or
 			(this.r and 0xff shl 16) or
 			(this.g and 0xff shl 8) or
 			(this.b and 0xff)

--- a/viz/d2v-viz-common/src/main/kotlin/io/data2viz/viz/RenderingTestSupport.kt
+++ b/viz/d2v-viz-common/src/main/kotlin/io/data2viz/viz/RenderingTestSupport.kt
@@ -2,6 +2,7 @@ package io.data2viz.viz
 
 import io.data2viz.color.*
 import io.data2viz.math.PI
+import io.data2viz.math.pct
 
 
 /**
@@ -351,7 +352,7 @@ val allRenderingTests = listOf(
                 radius = 100.0
                 style.fill = 0xfdc658.col
                 style.stroke = 0x0c0887.col
-                        .withAlpha(.5)
+                        .withAlpha(50.pct)
                 style.strokeWidth = 40.0
             }
         },

--- a/viz/d2v-viz-jfx/src/main/kotlin/io/data2viz/viz/JfxColorOrGradientRenderer.kt
+++ b/viz/d2v-viz-jfx/src/main/kotlin/io/data2viz/viz/JfxColorOrGradientRenderer.kt
@@ -11,7 +11,7 @@ typealias JfxLinearGradient = javafx.scene.paint.LinearGradient
 typealias JfxRadialGradient = javafx.scene.paint.RadialGradient
 
 val Color.jfxColor: javafx.scene.paint.Color
-	get() = javafx.scene.paint.Color.rgb(r, g, b, alpha)
+	get() = javafx.scene.paint.Color.rgb(r, g, b, alpha.value)
 
 
 fun ColorOrGradient.toPaint() = when(this) {
@@ -32,4 +32,4 @@ fun RadialGradient.toRadialGradientJFX(): JfxRadialGradient  = JfxRadialGradient
 	false,
 	CycleMethod.NO_CYCLE, colorStops.toStops())
 
-private fun List<ColorStop>.toStops(): List<Stop>? =  map { Stop(it.percent, it.color.jfxColor) }
+private fun List<ColorStop>.toStops(): List<Stop>? =  map { Stop(it.percent.value, it.color.jfxColor) }

--- a/viz/d2v-viz-js/src/main/kotlin/io/data2viz/viz/JsColorOrGradientRenderer.kt
+++ b/viz/d2v-viz-js/src/main/kotlin/io/data2viz/viz/JsColorOrGradientRenderer.kt
@@ -13,7 +13,7 @@ fun ColorOrGradient.toCanvasPaint(context: CanvasRenderingContext2D):Any = when(
 fun LinearGradient.toCanvasGradient(context: CanvasRenderingContext2D): CanvasGradient {
 	val gradient = context.createLinearGradient(x1, y1, x2, y2)
 	this.colorStops.forEach { cs ->
-		gradient.addColorStop(cs.percent, cs.color.rgba)
+		gradient.addColorStop(cs.percent.value, cs.color.rgba)
 	}
 	return gradient
 }
@@ -21,7 +21,7 @@ fun LinearGradient.toCanvasGradient(context: CanvasRenderingContext2D): CanvasGr
 fun RadialGradient.toCanvasGradient(context: CanvasRenderingContext2D): CanvasGradient {
 	val gradient = context.createRadialGradient(cx, cy, 0.0, cx, cy, radius)
 	this.colorStops.forEach { cs ->
-		gradient.addColorStop(cs.percent, cs.color.rgba)
+		gradient.addColorStop(cs.percent.value, cs.color.rgba)
 	}
 	return gradient
 }


### PR DESCRIPTION
Use percent whenever needed in colors to uniformize behaviors (ie. lightness was 0..1 in HCL but 0..100 in HSL...).
Use percent for alpha
Add some factories to create colors using Int

Then propagate changes: this mainly impacts the INTERPOLATE module and a few examples