### PR TITLE
Forces : fix issues and rename properties

### DIFF
--- a/examples/ex-force/ex-force-common/src/main/kotlin/ExForceCommon.kt
+++ b/examples/ex-force/ex-force-common/src/main/kotlin/ExForceCommon.kt
@@ -77,7 +77,7 @@ private fun simulationLoop() {
 //        simulation.addForce("${forces[forceIndex].first}_$index", forces[forceIndex].second[index])
 //    }
 //    simulation.intensity = 1.0
-//    simulation.velocityDecay = if (forceIndex == 2) 0.05 else 0.4
+//    simulation.friction = if (forceIndex == 2) 0.05 else 0.4
 //    timer(delay = 3500.0) {
 //        (0 until forces[forceIndex].second.size).forEach { index ->
 //            simulation.removeForce("${forces[forceIndex].first}_$index")

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceSimulation.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceSimulation.kt
@@ -139,17 +139,17 @@ class ForceSimulation<D> internal constructor() {
             field = value.coerceAtLeast(0.pct)
         }
 
+    private var _friction = 0.6
+
     /**
-     * Sets the velocity decay factor to the specified percentage in the range [0,100] which defaults to 40%.
-     * The decay factor is akin to atmospheric friction; after the application of any forces during a tick,
-     * each node’s velocity is multiplied by 1 - decay.
-     * As with lowering the intensity decay rate, less velocity decay may converge on a better solution, but risks
+     * Sets the friction factor to the specified percentage in the range [0,100] which defaults to 40%.
+     * As with lowering the intensity decay rate, less friction may converge on a better solution, but risks
      * numerical instabilities and oscillation.
      */
-    var velocityDecay = 60.pct
-        get() = 100.pct - field
+    var friction
+        get() = Percent(1 - _friction)
         set(value) {
-            field = 100.pct - value.coerceToDefault()
+            _friction = 1 - value.coerceToDefault().value
         }
 
     /**
@@ -184,7 +184,7 @@ class ForceSimulation<D> internal constructor() {
     /**
      * Increments the current intensity by (intensityTarget - intensity) × intensityDecay;
      * then invokes each registered force, passing the new intensity;
-     * then decrements each node’s velocity by velocity × velocityDecay;
+     * then decrements each node’s velocity by velocity × friction;
      * lastly increments each node’s position by velocity.
      *
      * This method does not dispatch events;
@@ -209,14 +209,14 @@ class ForceSimulation<D> internal constructor() {
                 node.x = node.fixedX!!
                 node.vx = .0
             } else {
-                node.vx *= velocityDecay.value
+                node.vx *= _friction
                 node.x += node.vx
             }
             if (node.fixedY != null) {
                 node.y = node.fixedY!!
                 node.vy = .0
             } else {
-                node.vy *= velocityDecay.value
+                node.vy *= _friction
                 node.y += node.vy
             }
         }

--- a/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceSimulation.kt
+++ b/force/d2v-force-common/src/main/kotlin/io/data2viz/force/ForceSimulation.kt
@@ -71,10 +71,8 @@ class ForceSimulation<D> internal constructor() {
 
     /**
      * Restarts current simulation
-     * TODO really ? only restart timer but intensity remains 1.0... should see what is expected and eventually also reset "started"
-     * TODO or call it "pause / unpause" instead of "stop / restart" https://github.com/d3/d3-force#simulation_restart
      */
-    fun restart() {
+    fun play() {
         stepper.restart { step() }
     }
 

--- a/force/d2v-force-jfx/src/test/kotlin/io/data2viz/force/ForceExJFX.kt
+++ b/force/d2v-force-jfx/src/test/kotlin/io/data2viz/force/ForceExJFX.kt
@@ -1,10 +1,14 @@
 import io.data2viz.color.Colors
 import io.data2viz.force.ForceLink
 import io.data2viz.force.Link
+import io.data2viz.force.SimulationEvent
 import io.data2viz.force.forceSimulation
+import io.data2viz.geom.Point
 import io.data2viz.geom.point
 import io.data2viz.geom.size
+import io.data2viz.math.deg
 import io.data2viz.math.pct
+import io.data2viz.random.RandomDistribution
 import io.data2viz.viz.*
 import javafx.application.Application
 import javafx.scene.Scene
@@ -52,75 +56,79 @@ class ForceExJFX : Application() {
 
 data class Stitch(var row:Int, var column:Int)
 
-val vizSize = 600.0
-val viewCenter = point(vizSize / 2, vizSize / 2)
-
-val networkSize = 17
-val totalNodes = networkSize * networkSize
-val linksDistance = 5.0
-
-fun graph(): Viz {
-
-    val particleVisuals = mutableListOf<CircleNode>()
-    val linkVisuals = mutableListOf<LineNode>()
-    val particles = (0 until totalNodes).map { Stitch(it % networkSize, it / networkSize) }
-
-    lateinit var constraintForce:ForceLink<Stitch>
-
-    val simulation = forceSimulation<Stitch> {
-        forceCenter {
-            center = viewCenter
-        }
-        forceNBody {
-            // each ForceNode will repel each other ForceNode
-            strengthGet = { -15.0 }
-        }
-        constraintForce = forceLink {
-            // link this ForceNode to other ForceNodes on the next row & column (if available)
-            linkGet = {
-                val links = mutableListOf<Link<Stitch>>()
-                if (domain.row < networkSize - 1) links.add(Link(this, nodes[index + 1], linksDistance))
-                if (domain.column < networkSize - 1) links.add(Link(this, nodes[index + networkSize], linksDistance))
-                links
-            }
-            iterations = 1
-        }
-        domainObjects = particles
-        intensityDecay = 0.pct
-    }
-
-    return viz {
-        size = size(vizSize, vizSize)
-        constraintForce.links.forEach { link ->
-            linkVisuals += line {
-                stroke = Colors.Web.lightslategrey
-            }
-        }
-        simulation.nodes.forEach { forceNode ->
-            particleVisuals += circle {
-                radius = 3.0
-                fill = Colors.Web.crimson
-            }
-        }
-
-        animation {
-            simulation.nodes.forEach { forceNode ->
-                particleVisuals[forceNode.index].apply {
-                    x = forceNode.x
-                    y = forceNode.y
-                }
-            }
-            constraintForce.links.forEachIndexed { index, link ->
-                linkVisuals[index].apply {
-                    x1 = link.source.x
-                    x2 = link.target.x
-                    y1 = link.source.y
-                    y2 = link.target.y
-                }
-            }
-        }
-    }
-}
+//val vizSize = 600.0
+//val viewCenter = point(vizSize / 2, vizSize / 2)
+//
+//val networkSize = 17
+//val totalNodes = networkSize * networkSize
+//val linksDistance = 5.0
+//
+//fun graph(): Viz {
+//
+//    val particleVisuals = mutableListOf<CircleNode>()
+//    val linkVisuals = mutableListOf<LineNode>()
+//    val particles = (0 until totalNodes).map { Stitch(it % networkSize, it / networkSize) }
+//
+//    lateinit var constraintForce:ForceLink<Stitch>
+//
+//    val simulation = forceSimulation<Stitch> {
+//        forceCenter {
+//            center = viewCenter
+//        }
+//        forceNBody {
+//            // each ForceNode will repel each other ForceNode
+//            strengthGet = { -15.0 }
+//        }
+//        constraintForce = forceLink {
+//            // link this ForceNode to other ForceNodes on the next row & column (if available)
+//            linkGet = {
+//                val links = mutableListOf<Link<Stitch>>()
+//                if (domain.row < networkSize - 1) links.add(Link(this, nodes[index + 1], linksDistance))
+//                if (domain.column < networkSize - 1) links.add(Link(this, nodes[index + networkSize], linksDistance))
+//                links
+//            }
+//            iterations = 1
+//        }
+//        domainObjects = particles
+//        intensityDecay = 2.pct
+//    }
+//
+//    return viz {
+//        size = size(vizSize, vizSize)
+//        constraintForce.links.forEach { link ->
+//            linkVisuals += line {
+//                stroke = Colors.Web.lightslategrey
+//            }
+//        }
+//        simulation.nodes.forEach { forceNode ->
+//            particleVisuals += circle {
+//                radius = 3.0
+//                fill = Colors.Web.crimson
+//            }
+//        }
+//
+//        animation {
+//            simulation.nodes.forEach { forceNode ->
+//                particleVisuals[forceNode.index].apply {
+//                    x = forceNode.x
+//                    y = forceNode.y
+//                }
+//            }
+//            constraintForce.links.forEachIndexed { index, link ->
+//                linkVisuals[index].apply {
+//                    x1 = link.source.x
+//                    x2 = link.target.x
+//                    y1 = link.source.y
+//                    y2 = link.target.y
+//                }
+//            }
+//            if (simulation.intensity < 1.pct) {
+//                println("STOP ANIM")
+//                stopAnimations()
+//            }
+//        }
+//    }
+//}
 
 
 
@@ -327,44 +335,46 @@ fun graph(): Viz {
 //    }
 //}
 
-//fun graph(): Viz {
-//
-//    val vizSize = 400.0
-//    val randPos = RandomDistribution.uniform(.0, vizSize)
-//    val viewCenter = point(vizSize / 2, vizSize / 2)
-//    val items = (0..2000).map { LayeredPoint(point(randPos(), randPos()), it%12 ) }
-//
-//    val simulation = forceSimulation<LayeredPoint> {
-//        forceRadial {
-//            centerGet = { viewCenter }
-//            radiusGet = { domain.layer * 17.0 }
-//        }
-//        domainObjects = items
-//
-//        intensity = 40.pct
-//        intensityDecay = 0.2.pct
-//
-//        initForceNode = {
-//            position = domain.position
-//        }
-//    }
-//
-//    val particles = mutableListOf<CircleNode>()
-//    return viz {
-//        size = size(vizSize, vizSize)
-//        simulation.nodes.forEach { forceNode ->
-//            particles += circle {
-//                radius = 5.0
-//                fill = Colors.hsl((forceNode.domain.layer * 30).deg, 100.pct, 50.pct)
-//            }
-//        }
-//        animation {
-//            simulation.nodes.forEach { forceNode ->
-//                particles[forceNode.index].apply {
-//                    x = forceNode.x
-//                    y = forceNode.y
-//                }
-//            }
-//        }
-//    }
-//}
+data class LayeredPoint(val position: Point, val layer:Int)
+
+fun graph(): Viz {
+
+    val vizSize = 400.0
+    val randPos = RandomDistribution.uniform(.0, vizSize)
+    val viewCenter = point(vizSize / 2, vizSize / 2)
+    val items = (0..2000).map { LayeredPoint(point(randPos(), randPos()), it%12 ) }
+
+    val simulation = forceSimulation<LayeredPoint> {
+        forceRadial {
+            centerGet = { viewCenter }
+            radiusGet = { domain.layer * 17.0 }
+        }
+        domainObjects = items
+
+
+//        friction = 99.pct
+
+        initForceNode = {
+            position = domain.position
+        }
+    }
+
+    val particles = mutableListOf<CircleNode>()
+    return viz {
+        size = size(vizSize, vizSize)
+        simulation.nodes.forEach { forceNode ->
+            particles += circle {
+                radius = 5.0
+                fill = Colors.hsl((forceNode.domain.layer * 30).deg, 100.pct, 50.pct)
+            }
+        }
+        animation {
+            simulation.nodes.forEach { forceNode ->
+                particles[forceNode.index].apply {
+                    x = forceNode.x
+                    y = forceNode.y
+                }
+            }
+        }
+    }
+}

--- a/force/d2v-force-jfx/src/test/kotlin/io/data2viz/force/ForceExJFX.kt
+++ b/force/d2v-force-jfx/src/test/kotlin/io/data2viz/force/ForceExJFX.kt
@@ -351,8 +351,8 @@ fun graph(): Viz {
         }
         domainObjects = items
 
-
-//        friction = 99.pct
+        intensityDecay = 0.1.pct
+        friction = 90.pct
 
         initForceNode = {
             position = domain.position


### PR DESCRIPTION
check issues #107 #108 and #109 
all these are small issues on FORCE module that need to be merged into develop.

- fix an issue on velocityDecay not working as intended
- fix an issue about the declaring order of domainObjects and initForceNode making it giving 2 different results (not as intended)
- change some properties names to better reflect their real meaning : 
   - velocityDecay -> friction
   - simulation.restart() -> simulation.play()