### PR TITLE
rendering text: replace \n with space when set string to TextNode.textContent

### DIFF
--- a/viz/d2v-viz-common/src/main/kotlin/io/data2viz/viz/TextNode.kt
+++ b/viz/d2v-viz-common/src/main/kotlin/io/data2viz/viz/TextNode.kt
@@ -12,12 +12,20 @@ class TextNode : Node(),
     var x: Double = .0
     var y: Double = .0
     var textContent: String = "Type something"
+    set(value) {
+        field = value.makeVizFriendlyText()
+    }
+
     var fontSize: Double = 12.0
     var fontFamily: FontFamily          = FontFamily.SANS_SERIF
     var fontWeight: FontWeight          = FontWeight.NORMAL
     var fontStyle: FontPosture          = FontPosture.NORMAL
 
 }
+
+private fun String.makeVizFriendlyText(): String = replaceNewLineWithSpace()
+
+private fun String.replaceNewLineWithSpace(): String  = replace('\n', ' ')
 
 
 class FontFamily private constructor(val name: String) {


### PR DESCRIPTION
#118 rendering text: replace \n with space when set string to TextNode.textContent. Previously \n have different behavior on JS & JFX
I replaced \n with space for all platforms because JS rendered \n as char sequence and JFX rendered as new line