### PR TITLE
#121 upgrade gradle version to 4.10.3 & include android modules in build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ examples_dist=false
 
 
 # project activation
-include_android=false
+include_android=true
 include_js=true
 include_jfx=true
 include_jfx_renderings=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
I have similar errors with 4.6
I solved issue by upgrading to 4.10.3 (latest 4.x version for now). 
I also included android modules in build to show compatibility. Android & JFX modules had conflicts previously (JFX build error) with old gradle version. With 4.10.3 you shouldn't disable Android modules to run JFX.
Currently
-  It not possible to run JFX via click on main method in IDE + run (as Kotlin application) 

> Error: Could not find or load main class io.data2viz.examples.geo.EarthApplication

- but it runs via `build :run` task on JFX module
-  It possible to run Android as app via IDEA and via gradle action
- It possible to build js modules via Gradle and gradle from IDE
- It is possible to build whole project via shift + f9 from IDE. Previously error was thrown

I think we should put somewhere in docs information about build:
- the best option is to build via gradle tasks (from terminal or IDEA gradle view)
- to run Android application you should run `:installDebug` task like `./gradlew :app:installDebug`
- to tun JFX application you should run `:run` task like `./gradlew :ex-geo:ex-geo-jfx:run`
- to build JS files you should run `:build` like `./gradlew :ex-geo:ex-geo-js:build` and open `index.html` in module directory