### PR TITLE
Fix Android VizView rendering nothing

### DIFF
--- a/viz/src/androidMain/kotlin/io/data2viz/viz/VizView.kt
+++ b/viz/src/androidMain/kotlin/io/data2viz/viz/VizView.kt
@@ -48,7 +48,7 @@ public class VizView(
         }
 
         renderer.canvas = canvas
-        renderer.render()
+        renderer.draw()
     }
 
 


### PR DESCRIPTION
Recent changes to the Android Canvas Renderer made it so that `renderer.draw()` would only call `invalidate()` again, resulting in nothing being rendered. This fixes that.